### PR TITLE
Parse state bit flags for extra player info

### DIFF
--- a/libmelee/melee/console.py
+++ b/libmelee/melee/console.py
@@ -981,10 +981,46 @@ class Console:
         playerstate.action_frame = int(np.ndarray((1,), ">f", event_bytes, 0x22)[0])
 
         try:
-            sb4 = int(np.ndarray((1,), ">B", event_bytes, 0x29)[0])
-            playerstate.is_powershield = (sb4 & 0x20) == 0x20
+            sb1 = int(np.ndarray((1,), ">B", event_bytes, 0x26)[0])
         except TypeError:
-            playerstate.is_powershield = False
+            sb1 = 0
+        playerstate.is_absorbing = (sb1 & 0x02) == 0x02
+        playerstate.reflect_owner_doesnt_change = (sb1 & 0x08) == 0x08
+        playerstate.is_reflect_active = (sb1 & 0x10) == 0x10
+
+        try:
+            sb2 = int(np.ndarray((1,), ">B", event_bytes, 0x27)[0])
+        except TypeError:
+            sb2 = 0
+        playerstate.is_subaction_invulnerable = (sb2 & 0x04) == 0x04
+        playerstate.is_fastfalling = (sb2 & 0x08) == 0x08
+        playerstate.is_defender_in_hitlag = (sb2 & 0x10) == 0x10
+        playerstate.is_in_hitlag = (sb2 & 0x20) == 0x20
+
+        try:
+            sb3 = int(np.ndarray((1,), ">B", event_bytes, 0x28)[0])
+        except TypeError:
+            sb3 = 0
+        playerstate.is_holding_character = (sb3 & 0x04) == 0x04
+        playerstate.is_shield_active = (sb3 & 0x80) == 0x80
+
+        try:
+            sb4 = int(np.ndarray((1,), ">B", event_bytes, 0x29)[0])
+        except TypeError:
+            sb4 = 0
+        playerstate.is_in_hitstun = (sb4 & 0x02) == 0x02
+        playerstate.is_touching_shield = (sb4 & 0x04) == 0x04
+        playerstate.is_powershield = (sb4 & 0x20) == 0x20
+
+        try:
+            sb5 = int(np.ndarray((1,), ">B", event_bytes, 0x2A)[0])
+        except TypeError:
+            sb5 = 0
+        playerstate.is_cloaked = (sb5 & 0x02) == 0x02
+        playerstate.is_follower = (sb5 & 0x08) == 0x08
+        playerstate.is_inactive = (sb5 & 0x10) == 0x10
+        playerstate.is_dead = (sb5 & 0x40) == 0x40
+        playerstate.is_offscreen = (sb5 & 0x80) == 0x80
 
         try:
             playerstate.hitstun_frames_left = int(np.ndarray((1,), ">f", event_bytes, 0x2B)[0])

--- a/libmelee/melee/gamestate.py
+++ b/libmelee/melee/gamestate.py
@@ -76,7 +76,10 @@ class PlayerState(object):
                  'speed_ground_x_self', 'cursor_x', 'cursor_y', 'coin_down', 'controller_status', 'off_stage', 'iasa',
                  'moonwalkwarning', 'controller_state', 'ecb_bottom', 'ecb_top', 'ecb_left', 'ecb_right',
                  'costume', 'cpu_level', 'is_holding_cpu_slider', 'nana', 'position', 'cursor', 'ecb', 'nickName', 'connectCode',
-                 'displayName', 'team_id', 'is_powershield')
+                 'displayName', 'team_id', 'is_powershield', 'is_absorbing', 'reflect_owner_doesnt_change',
+                 'is_reflect_active', 'is_subaction_invulnerable', 'is_fastfalling', 'is_defender_in_hitlag',
+                 'is_in_hitlag', 'is_holding_character', 'is_shield_active', 'is_in_hitstun',
+                 'is_touching_shield', 'is_cloaked', 'is_follower', 'is_inactive', 'is_dead', 'is_offscreen')
     def __init__(self):
         # This value is what the character currently is IN GAME
         #   So this will have no meaning while in menus
@@ -174,6 +177,39 @@ class PlayerState(object):
         """(string): The Slippi Online display name for the play. Might be blank"""
         self.team_id = 0
         """(int): The team ID of the player. This is different than costume, and only relevant during teams."""
+
+        self.is_absorbing = False
+        """(bool): Is absorber active (e.g. G&W bucket)"""
+        self.reflect_owner_doesnt_change = False
+        """(bool): Reflect active without changing projectile ownership"""
+        self.is_reflect_active = False
+        """(bool): Is reflect active"""
+        self.is_subaction_invulnerable = False
+        """(bool): Has temporary intangibility or invincibility from subaction"""
+        self.is_fastfalling = False
+        """(bool): Is fastfalling"""
+        self.is_defender_in_hitlag = False
+        """(bool): Is the defender in hitlag (not shield hitlag)"""
+        self.is_in_hitlag = False
+        """(bool): Is in hitlag"""
+        self.is_holding_character = False
+        """(bool): Is holding another character due to grab/command grab"""
+        self.is_shield_active = False
+        """(bool): Is shield active"""
+        self.is_in_hitstun = False
+        """(bool): Is in hitstun"""
+        self.is_touching_shield = False
+        """(bool): Owner's detection hitbox is touching shield bubble"""
+        self.is_cloaked = False
+        """(bool): Is cloaking device active"""
+        self.is_follower = False
+        """(bool): Is follower (e.g. Nana)"""
+        self.is_inactive = False
+        """(bool): Is inactive"""
+        self.is_dead = False
+        """(bool): Is dead"""
+        self.is_offscreen = False
+        """(bool): Is offscreen"""
 
 class Projectile:
     """ Represents the state of a projectile (items, lasers, etc...) """


### PR DESCRIPTION
## Summary
- expose state bit flag fields in `PlayerState`
- decode state bit flags 1-5 in post-frame events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'enet')*
- `pip install enet` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_6890d986810483239eb793cabac27d73