### PR TITLE
Document inference and dataset utilities with concrete examples

### DIFF
--- a/controller_quantization.py
+++ b/controller_quantization.py
@@ -36,13 +36,39 @@ _C_STICK_NORM_CACHE: Dict[Tuple[str, Optional[int]], torch.Tensor] = {}
 
 # TODO: Do we need clamp here?
 def sticks01_to_unit11(xy01: torch.Tensor) -> torch.Tensor:
-    """Map controller coordinates from [0,1] to [-1,1] and clamp to the unit circle."""
+    """Map controller coordinates from ``[0, 1]`` to ``[-1, 1]`` with a worked example.
+
+    Example
+    -------
+    Consider ``xy01 = tensor([[0.2, 0.8], [1.3, -0.4]])``.
+
+    1. Multiply by ``2`` and subtract ``1`` to rescale the square:
+       ``xy11 = xy01 * 2 - 1`` gives ``[[-0.6, 0.6], [1.6, -1.8]]``.
+    2. Clamp each element to ``[-1, 1]`` so impossible analog values snap to the
+       stick limits, resulting in ``[[-0.6, 0.6], [1.0, -1.0]]``.
+    3. Call :func:`_clamp_unit_circle` so that ``(1.0, -1.0)`` is renormalized to
+       lie on the perimeter of the unit circle (the vector has length ``√2`` so it
+       is divided by ``√2``), yielding ``[[-0.6, 0.6], [0.7071, -0.7071]]``.
+
+    The returned tensor therefore mirrors exactly how analog sticks are scaled and
+    saturated before palette lookup in quantization.
+    """
     xy11 = torch.clamp(xy01 * 2.0 - 1.0, -1.0, 1.0)
     return _clamp_unit_circle(xy11)
 
 
 def _clamp_unit_circle(xy11: torch.Tensor) -> torch.Tensor:
-    """Clamp arbitrary stick coordinates in [-1,1] to the unit circle."""
+    """Project stick coordinates in ``[-1, 1]`` back onto the unit circle.
+
+    Example
+    -------
+    With ``xy11 = tensor([[0.9, 0.9], [0.3, -0.4]])`` the squared radii are
+    ``[1.62, 0.25]``. Only the first row exceeds ``1`` so we divide it by its
+    radius ``sqrt(1.62) ≈ 1.2728`` to produce ``[0.7071, 0.7071]`` while the
+    second row remains ``[0.3, -0.4]``. The function therefore returns
+    ``tensor([[0.7071, 0.7071], [0.3, -0.4]])`` showing how just the overflowing
+    vectors are rescaled.
+    """
     # Optimized: use squared norm to avoid sqrt, then only normalize if needed
     radius_sq = (xy11 * xy11).sum(dim=-1, keepdim=True)
     # Only normalize if radius > 1
@@ -55,7 +81,18 @@ def _clamp_unit_circle(xy11: torch.Tensor) -> torch.Tensor:
 
 
 def _device_cache_key(device: torch.device) -> Tuple[str, Optional[int]]:
-    """Canonicalize device key to support caching with and without explicit indices."""
+    """Canonicalize a :class:`torch.device` for palette caching with an example.
+
+    Example
+    -------
+    * ``torch.device("cuda")`` with CUDA available resolves to
+      ``("cuda", current_device())`` so that the cache differentiates GPU cards.
+    * ``torch.device("cpu")`` becomes ``("cpu", None)`` to share CPU copies.
+
+    Given two successive calls with these devices, the quantization helper will
+    reuse the cached palettes because the tuple keys are stable regardless of how
+    the device objects were constructed.
+    """
     if device.type == "cuda":
         index = device.index
         if index is None and torch.cuda.is_available():
@@ -69,7 +106,21 @@ def _palette_for_device(
     cache: Dict[Tuple[str, Optional[int]], torch.Tensor],
     device: torch.device,
 ) -> torch.Tensor:
-    """Return palette tensor on the requested device, caching to avoid repeated copies."""
+    """Move a palette tensor to ``device`` once and reuse the cached copy.
+
+    Example
+    -------
+    Suppose ``cpu_palette`` is ``tensor([[0., 0.], [1., 0.]])`` and ``device`` is
+    ``cuda:0``:
+
+    1. The cache is initially empty so ``key=('cuda', 0)`` is missing.
+    2. The palette is transferred using ``cpu_palette.to(device)`` and stored.
+    3. A second call with the same device hits the cache and returns the already
+       moved tensor without copying again.
+
+    Passing ``torch.device('cpu')`` simply returns ``cpu_palette`` directly,
+    showing how CPU execution avoids needless clones.
+    """
     if device.type == "cpu":
         return cpu_palette
     key = _device_cache_key(device)
@@ -89,7 +140,27 @@ def _quantize_stick(
     B: int,
     L: int,
 ) -> torch.Tensor:
-    """Helper to quantize a stick to palette indices."""
+    """Convert continuous stick coordinates to palette indices via distance.
+
+    Example
+    -------
+    With ``B=1`` and ``L=2`` the tensor ``xy`` might be
+    ``tensor([[[0.1, 0.9], [1.1, -0.2]]])``. When ``input_domain='auto'`` the
+    helper inspects the values and:
+
+    1. Detects that the second row exceeds ``1``, so the entire block is clamped
+       to ``[-1, 1]`` and projected onto the unit circle, becoming
+       ``[[0.1, 0.9], [0.9806, -0.1961]]`` in ``[-1, 1]`` space.
+    2. Flattens to ``V`` with shape ``(2, 2)`` and computes squared norms
+       ``[0.82, 0.9999]`` and dot products against the palette.
+    3. Uses ``||V||^2 - 2V·P + ||P||^2`` to produce a distance matrix where each
+       row lists the squared distance to every palette entry.
+    4. Applies ``argmin`` per row and reshapes the indices back to ``(B, L)`` so
+       the first frame might map to palette index ``3`` and the second to ``7``.
+
+    The returned index tensor is therefore ready for embedding lookups or
+    cross-entropy training targets while faithfully following the stick geometry.
+    """
     if input_domain == "unit11":
         xy11 = _clamp_unit_circle(torch.clamp(xy, -1.0, 1.0))
     elif input_domain == "unit01":
@@ -117,18 +188,34 @@ def quantize_targets(
     *,
     input_domain: str = "auto",
 ) -> Dict[str, torch.Tensor]:
-    """Convert controller targets to palette indices.
+    """Quantize raw controller targets with a frame-by-frame walkthrough.
 
-    Parameters
-    ----------
-    batch_Y:
-        Target tensor [..., features].
-    colmap:
-        Column map describing which slices correspond to controller fields.
-    input_domain:
-        "unit01" if the incoming stick coordinates are in [0,1],
-        "unit11" if they are already in [-1,1],
-        "auto" (default) to inspect the data and choose automatically.
+    Example
+    -------
+    Imagine ``batch_Y`` has shape ``(2, 3, F)`` where the column map says the
+    first two feature columns are ``p1_main_stick_(x, y)``, the next two are
+    ``p1_c_stick_(x, y)``, and button probabilities follow. For the first batch
+    element we might have::
+
+        main stick  -> [[0.2, 0.8], [1.1, -0.4], [0.5, 0.5]]
+        c-stick     -> [[0.0, 1.0], [0.4, 0.4], [0.8, 0.1]]
+        buttons     -> [[0.7, 0.1, 0.9, 0.0, 0.2], ...]
+
+    ``quantize_targets`` performs the following steps for each batch:
+
+    1. Slice stick blocks using ``colmap`` and move the precomputed palettes to
+       the tensor's device with :func:`_palette_for_device`.
+    2. Call :func:`_quantize_stick` to map every ``(x, y)`` vector to the nearest
+       palette entry. For the first main-stick frame above the nearest palette
+       might be ``[-0.125, 0.875]`` at index ``14``.
+    3. Repeat for the C-stick and (optionally) shoulder analog values, producing
+       integer index tensors shaped like ``(B, L)``.
+    4. Clamp button probabilities into ``[0, 1]`` without otherwise changing
+       their shape, keeping them ready for BCE losses.
+
+    The returned dictionary contains the quantized indices, the button tensor,
+    and metadata about palette cardinalities so callers can set up embeddings or
+    classification heads without re-deriving these values.
     """
     B, L, _ = batch_Y.shape
     device = batch_Y.device

--- a/feature_transforms.py
+++ b/feature_transforms.py
@@ -46,11 +46,29 @@ class FeatureTransformSpec:
 
 
 def _transform_scale(column: np.ndarray, *, factor: float) -> np.ndarray:
+    """Scale a feature column in-place with a concrete walkthrough.
+
+    Example
+    -------
+    ``column`` is ``array([1.0, -2.0, 0.5], dtype=float32)`` and ``factor=0.1``.
+    We multiply elementwise, producing ``[0.1, -0.2, 0.05]`` which replaces the
+    original array contents. The updated array is returned so chained transforms
+    can continue using the same buffer.
+    """
     column *= factor
     return column
 
 
 def _transform_offset(column: np.ndarray, *, delta: float) -> np.ndarray:
+    """Shift a feature column in-place and illustrate the effect.
+
+    Example
+    -------
+    With ``column = array([-1.0, 0.0, 2.0])`` and ``delta=5`` we perform
+    ``column += 5`` so the buffer becomes ``[4.0, 5.0, 7.0]``. The returned view
+    allows downstream code to observe the shifted values without additional
+    copies.
+    """
     column += delta
     return column
 
@@ -61,6 +79,21 @@ TransformFactory = Callable[[Mapping[str, Any]], FeatureFn]
 # TODO: might not need mask or clip
 # TODO: This is duplicated elsewhere
 def _sticks01_to_unit11_np(xy01: np.ndarray) -> np.ndarray:
+    """Rescale ``[0, 1]`` stick coordinates to ``[-1, 1]`` with unit-circle clamping.
+
+    Example
+    -------
+    Given ``xy01 = array([[0.0, 1.0], [0.75, 0.75]])``:
+
+    1. Clip values to ``[0, 1]`` (already satisfied).
+    2. Multiply by ``2`` and subtract ``1`` giving ``[[-1.0, 1.0], [0.5, 0.5]]``.
+    3. Compute norms ``[√2, √0.5]`` and divide the overflowing ``[-1, 1]`` vector
+       by ``√2`` so it lands on ``[-0.7071, 0.7071]`` while the second row stays
+       untouched.
+
+    The returned array is therefore suitable for palette quantization in the
+    exact format produced by training.
+    """
     xy01_clipped = np.clip(xy01, 0.0, 1.0)
     xy11 = xy01_clipped * 2.0 - 1.0
     norms = np.linalg.norm(xy11, axis=1, keepdims=True)
@@ -87,6 +120,24 @@ def _stick_palette_apply(
     palette: np.ndarray,
     palette_norm: np.ndarray,
 ) -> np.ndarray:
+    """Quantize ``(x, y)`` stick pairs to the nearest entry in ``palette``.
+
+    Example
+    -------
+    Suppose ``block`` contains two rows ``[[0.1, 0.9], [1.2, -0.4]]`` and the
+    palette has the four cardinal directions ``[[1, 0], [0, 1], [-1, 0], [0, -1]]``.
+
+    1. Because values exceed ``1`` we clamp to ``[-1, 1]`` and renormalize, giving
+       ``[[0.1, 0.9], [0.9487, -0.3162]]``.
+    2. Compute dot products against the palette and the precomputed norms to build
+       squared distances. The first vector is closest to ``[0, 1]`` (index ``1``)
+       while the second lands near ``[1, 0]`` (index ``0``).
+    3. Replace each row with the winning palette vector so ``block`` becomes
+       ``[[0, 1], [1, 0]]`` before being returned.
+
+    This in-place workflow mirrors how sequences are quantized during dataset
+    creation and training.
+    """
     if block.shape[1] != 2:
         raise ValueError(
             "stick_palette transform expects exactly two feature columns (x, y)."
@@ -111,6 +162,16 @@ def _stick_palette_apply(
 
 
 def _factory_stick_palette(params: Mapping[str, Any]) -> FeatureFn:
+    """Build a stick palette transform and show how configuration is resolved.
+
+    Example
+    -------
+    When ``params={'palette': 'main'}`` the factory selects the Fox main-stick
+    palette, precomputes its squared norms, and returns a function equivalent to
+    ``lambda block: _stick_palette_apply(block, palette=_MAIN_PALETTE, ...)``.
+    Applying this function to a ``(N, 2)`` array therefore snaps each row to the
+    nearest discrete stick direction consistent with quantization.
+    """
     palette_key = str(params.get("palette", "fox_main")).lower()
     palette = _PALETTES.get(palette_key)
     if palette is None:
@@ -123,6 +184,15 @@ def _factory_stick_palette(params: Mapping[str, Any]) -> FeatureFn:
 
 
 def _factory_scale(params: Mapping[str, Any]) -> FeatureFn:
+    """Create a multiplicative transform from configuration parameters.
+
+    Example
+    -------
+    Given ``params={'factor': 0.5}`` the factory returns a function that, when
+    passed ``array([2.0, -4.0])``, multiplies the data by ``0.5`` to produce
+    ``[1.0, -2.0]``. This mirrors how YAML/JSON transform specs reduce analog
+    ranges before batching.
+    """
     raw = params.get("factor", params.get("scale", 1.0))
     try:
         factor = float(raw)
@@ -132,6 +202,15 @@ def _factory_scale(params: Mapping[str, Any]) -> FeatureFn:
 
 
 def _factory_offset(params: Mapping[str, Any]) -> FeatureFn:
+    """Create an additive transform and illustrate its effect.
+
+    Example
+    -------
+    ``params={'delta': -3}`` produces a callable that subtracts ``3`` from any
+    supplied column. Applying it to ``array([5., 6.])`` yields ``[2., 3.]`` which
+    is returned to the caller, matching the shift semantics used during
+    preprocessing.
+    """
     raw = params.get("delta", params.get("offset", params.get("value")))
     if raw is None:
         raise TypeError("Offset transform requires a 'delta'.")
@@ -150,6 +229,15 @@ _TRANSFORM_FACTORIES: Dict[str, TransformFactory] = {
 
 
 def _resolve_registered_transform(name: str, params: Mapping[str, Any]) -> FeatureFn:
+    """Lookup a registered transform factory and demonstrate a lookup failure.
+
+    Example
+    -------
+    * ``_resolve_registered_transform('scale', {'factor': 2})`` returns the scale
+      function described above.
+    * Passing ``'unknown'`` raises ``ValueError("Unknown feature transform 'unknown'.")``,
+      so configuration errors are surfaced immediately instead of at runtime.
+    """
     factory = _TRANSFORM_FACTORIES.get(name)
     if factory is None:
         raise ValueError(f"Unknown feature transform '{name}'.")
@@ -157,6 +245,16 @@ def _resolve_registered_transform(name: str, params: Mapping[str, Any]) -> Featu
 
 
 def _normalize_features(raw: Any) -> Tuple[str, ...]:
+    """Normalize transform feature declarations with a concrete case analysis.
+
+    Example
+    -------
+    * ``raw='p1_main_stick_x'`` becomes ``('p1_main_stick_x',)``.
+    * ``raw=['p1_main_stick_x', 'p1_main_stick_y']`` preserves order while
+      stripping whitespace.
+    * An empty list triggers ``ValueError`` showing how the helper guards against
+      silent misconfiguration.
+    """
     if isinstance(raw, str):
         raw_features: Iterable[str] = (raw,)
     elif isinstance(raw, Sequence) and not isinstance(raw, (bytes, bytearray)):
@@ -172,6 +270,16 @@ def _normalize_features(raw: Any) -> Tuple[str, ...]:
 def _extract_params(
     step: Mapping[str, Any], base_keys: Sequence[str]
 ) -> Mapping[str, Any]:
+    """Derive transform parameters from multiple configuration styles.
+
+    Example
+    -------
+    For a YAML entry ``{'transform': 'scale', 'features': 'foo', 'factor': 0.1}``
+    the helper returns ``{'factor': 0.1}`` because ``'factor'`` is not in
+    ``base_keys``. If the mapping already has ``'params': {'factor': 0.1}`` it is
+    returned verbatim, demonstrating how both explicit and implicit parameter
+    encodings converge to the same dictionary.
+    """
     params = step.get("params")
     if params is None:
         params = step.get("parameters")
@@ -183,6 +291,21 @@ def _extract_params(
 
 
 def _parse_step_mapping(step: Mapping[str, Any], idx: int) -> FeatureTransformStep:
+    """Parse a single mapping into :class:`FeatureTransformStep` with validation.
+
+    Example
+    -------
+    Given ``step={'transform': 'scale', 'features': ['foo'], 'factor': 2}`` the
+    helper:
+
+    1. Extracts ``'scale'`` as the transform name and normalizes ``['foo']`` to a
+       tuple.
+    2. Calls :func:`_extract_params` to build ``{'factor': 2}``.
+    3. Resolves the factory and returns ``FeatureTransformStep('scale', ('foo',), fn)``.
+
+    If the mapping omitted ``'features'`` a ``KeyError`` is raised with the index
+    ``idx`` embedded so configuration errors are easy to locate.
+    """
     transform_name = step.get("transform") or step.get("name")
     if not transform_name:
         raise KeyError(f"Transform spec at index {idx} missing 'transform'.")
@@ -199,13 +322,36 @@ def _parse_step_mapping(step: Mapping[str, Any], idx: int) -> FeatureTransformSt
 
 
 def _parse_step(raw: Any, idx: int) -> FeatureTransformStep:
+    """Dispatch to :func:`_parse_step_mapping` while guarding the input type.
+
+    Example
+    -------
+    * Passing a mapping proxies to :func:`_parse_step_mapping`.
+    * Passing a list triggers ``TypeError("Each transform spec must be a mapping.")``
+      so malformed configuration nodes are rejected early in the load process.
+    """
     if isinstance(raw, Mapping):
         return _parse_step_mapping(raw, idx)
     raise TypeError("Each transform spec must be a mapping.")
 
 
 def build_transform_spec(transforms: Any) -> Optional[FeatureTransformSpec]:
-    """Normalize raw configuration into a FeatureTransformSpec."""
+    """Normalize raw configuration into a :class:`FeatureTransformSpec`.
+
+    Example
+    -------
+    If ``transforms`` is::
+
+        [
+            {'transform': 'scale', 'features': 'foo', 'factor': 0.5},
+            {'transform': 'offset', 'features': ['foo', 'bar'], 'delta': 1},
+        ]
+
+    the function returns a spec with two ordered steps whose callables first
+    multiply column ``foo`` by ``0.5`` then add ``1`` to both ``foo`` and
+    ``bar``. Passing ``None`` yields ``None``, mirroring how ``FeatureConfig``
+    omits transformations by default.
+    """
 
     if not transforms:
         return None
@@ -222,6 +368,16 @@ def build_transform_spec(transforms: Any) -> Optional[FeatureTransformSpec]:
 def feature_spec_from_config(
     feature_cfg: "FeatureConfig",
 ) -> Optional[FeatureTransformSpec]:
+    """Extract the transform spec from a :class:`FeatureConfig` instance.
+
+    Example
+    -------
+    When ``feature_cfg.transforms`` already contains a parsed
+    :class:`FeatureTransformSpec`, the function returns it unchanged. If the field
+    stores raw configuration such as ``[{'transform': 'scale', ...}]`` the helper
+    passes that list to :func:`build_transform_spec` so callers always receive a
+    normalized object or ``None``.
+    """
     transforms = getattr(feature_cfg, "transforms", None)
     return build_transform_spec(transforms)
 

--- a/model_interface.py
+++ b/model_interface.py
@@ -69,6 +69,16 @@ class ControllerState:
 
     @staticmethod
     def neutral() -> "ControllerState":
+        """Return a neutral controller state with a concrete illustration.
+
+        Example
+        -------
+        Calling ``ControllerState.neutral()`` yields a state where the analog
+        sticks point to ``0.5`` (the Dolphin neutral value), the shoulder analog
+        is ``0.0``, and all digital buttons are ``False``. Passing this object to
+        :func:`apply_model_outputs_to_game` leaves the character idle, which is
+        exactly what the inference engine emits during warm-up.
+        """
         print("[TRACE:ControllerState.neutral] Creating neutral controller state")
         return ControllerState(
             main_stick_x=0.5,
@@ -102,21 +112,59 @@ class ModelFrameInputs(Mapping[str, float]):
     transformed: Dict[str, float]
 
     def __getitem__(self, key: str) -> float:
+        """Return the transformed value for ``key`` mirroring dict access.
+
+        Example
+        -------
+        With ``inputs = ModelFrameInputs({'foo': 1.0}, {'foo': 3.14})`` the call
+        ``inputs['foo']`` returns ``3.14``. Attempting to access a missing key
+        raises ``KeyError`` the same way as a standard dictionary.
+        """
         return self.transformed[key]
 
     def __iter__(self) -> Iterator[str]:
+        """Iterate over transformed feature names just like a dictionary.
+
+        Example
+        -------
+        ``list(inputs)`` yields ``['foo']`` for the example above, allowing the
+        object to integrate with APIs that expect a mapping view of features.
+        """
         return iter(self.transformed)
 
     def __len__(self) -> int:
+        """Expose the number of transformed features in the mapping.
+
+        Example
+        -------
+        ``len(inputs)`` evaluates to ``1`` for the example, which matches the
+        count of keys returned by ``__iter__``.
+        """
         return len(self.transformed)
 
     def as_dict(self) -> Dict[str, float]:
+        """Copy the transformed mapping into a standalone ``dict``.
+
+        Example
+        -------
+        ``inputs.as_dict()`` returns ``{'foo': 3.14}``. Mutating this dictionary
+        does not alter the underlying ``ModelFrameInputs`` object, making it safe
+        to hand to logging or serialization routines.
+        """
         return dict(self.transformed)
 
 
 # TODO: We probably have other "safe" functions, maybe we can put them all in one place
 # TODO: Why do we even need this, can't we just always know our types?
 def _safe_float(value: object) -> float:
+    """Convert ``value`` to ``float`` while logging failures with an example.
+
+    Example
+    -------
+    ``_safe_float(np.int32(7))`` returns ``7.0``. If ``value='abc'`` the helper
+    prints a trace line and re-raises the ``ValueError`` so callers see which
+    feature failed to coerce during inference.
+    """
     try:
         return float(value)
     except Exception as e:
@@ -125,6 +173,15 @@ def _safe_float(value: object) -> float:
 
 # TODO: called 63 times per frame, there has to be a better way
 def _coerce_scalar(value: object) -> float | int | bool:
+    """Convert arbitrary scalars to Python ``bool``/``int``/``float``.
+
+    Example
+    -------
+    ``_coerce_scalar(np.bool_(True))`` returns ``True`` while
+    ``_coerce_scalar(np.float32(1.5))`` returns ``1.5``. Passing an object such as
+    ``{'not': 'a scalar'}`` raises ``TypeError("Unable to coerce value ...")`` so
+    malformed schema values surface immediately.
+    """
     # print(f"[TRACE:_coerce_scalar] Coercing value of type {type(value)}")
     if isinstance(value, (bool, int, float)):
         # print("[TRACE:_coerce_scalar] Value is already bool/int/float")
@@ -144,7 +201,16 @@ def _coerce_scalar(value: object) -> float | int | bool:
 
 
 def set_feature_transforms(transforms: Optional[Any]) -> None:
-    """Configure per-feature transforms used at inference time."""
+    """Configure per-feature transforms used at inference time with a demo.
+
+    Example
+    -------
+    Passing ``[{'transform': 'scale', 'features': 'foo', 'factor': 0.5}]`` builds a
+    spec via :func:`build_transform_spec` and stores it in the module-level cache.
+    Subsequent calls to :func:`_apply_transforms_to_features` will then halve the
+    ``foo`` feature before inference. Passing ``None`` clears the spec, restoring
+    identity transforms.
+    """
     print(f"[TRACE:set_feature_transforms] Called with transforms={transforms is not None}")
 
     global _FEATURE_TRANSFORMS_SPEC
@@ -162,6 +228,16 @@ set_feature_transforms(FeatureConfig().transforms)
 
 # TODO: overly generic, maybe can cache some?
 def _apply_transforms_to_features(features: Dict[str, float]) -> Dict[str, float]:
+    """Apply the configured transform spec to the ``features`` mapping.
+
+    Example
+    -------
+    Suppose ``features={'foo': 4.0, 'bar': 1.0}`` and the global spec contains two
+    steps: scale ``foo`` by ``0.5`` and add ``1`` to both ``foo`` and ``bar``. The
+    helper copies the mapping, resolves ``foo`` groups, and produces
+    ``{'foo': 3.0, 'bar': 2.0}``, illustrating the same pipeline that runs before
+    every inference call.
+    """
     # print(f"[TRACE:_apply_transforms_to_features] Called with {len(features)} features")
     spec = _FEATURE_TRANSFORMS_SPEC
     if not spec or not spec.steps:
@@ -182,6 +258,16 @@ def _apply_transforms_to_features(features: Dict[str, float]) -> Dict[str, float
 
     # TODO: Surely we can cache this, or maybe even remove the need for it?
     def _resolve_groups(requested: Sequence[str]) -> List[Tuple[str, ...]]:
+        """Expand ``requested`` feature names to actual keys with prefix handling.
+
+        Example
+        -------
+        With ``requested=('main_stick_x', 'main_stick_y')`` and prefixed keys
+        available, this helper returns groups like
+        ``('p1_main_stick_x', 'p1_main_stick_y')`` and
+        ``('p2_main_stick_x', 'p2_main_stick_y')`` so transforms execute for both
+        players independently.
+        """
         # print(f"[TRACE:_resolve_groups] Resolving {len(requested)} requested features")
         if all(name in key_set for name in requested):
             # print("[TRACE:_resolve_groups] All features found in key_set, returning single group")
@@ -248,6 +334,15 @@ def _apply_transforms_to_features(features: Dict[str, float]) -> Dict[str, float
 def _controller_state_to_features(
         prefix: str, state: ControllerState
 ) -> Dict[str, float]:
+    """Convert a :class:`ControllerState` into prefixed feature values.
+
+    Example
+    -------
+    ``_controller_state_to_features('p1', ControllerState.neutral())`` produces a
+    dictionary where ``'p1_main_stick_x'`` equals ``0.5`` and all button keys are
+    ``0.0``. The inference engine caches this mapping to seed controller history
+    before live predictions.
+    """
     print(f"[TRACE:_controller_state_to_features] Converting controller state with prefix={prefix}")
     return {
         f"{prefix}_button_a": float(state.button_a),
@@ -264,11 +359,28 @@ def _controller_state_to_features(
 
 
 def _zero_player_fields(prefix: str) -> Dict[str, float]:
+    """Return zero-valued player features for ``prefix``.
+
+    Example
+    -------
+    ``_zero_player_fields('p2')`` yields entries like ``{'p2_stock': 0}`` and
+    ``{'p2_main_stick_x': 0.0}``, matching the neutral placeholders used when an
+    opponent is absent from the gamestate.
+    """
     print(f"[TRACE:_zero_player_fields] Creating zero fields for prefix={prefix}")
     return {f"{prefix}_{name}": dtype(0) for name, dtype in PLAYER_SPEC}
 
 
 def _prefixed_player_fields(player, prefix: str) -> Dict[str, float]:
+    """Extract prefixed player fields or fall back to zeros.
+
+    Example
+    -------
+    If ``player`` has valid stats, the helper returns values such as
+    ``{'p1_percent': 23.0}``. When ``player`` is ``None`` the output equals
+    :func:`_zero_player_fields(prefix)`, ensuring callers receive a complete feature
+    dictionary regardless of the gamestate.
+    """
     print(f"[TRACE:_prefixed_player_fields] Extracting fields for prefix={prefix}")
     if player is None or getattr(player, "controller_state", None) is None:
         print("[TRACE:_prefixed_player_fields] Player is None or has no controller_state, returning zeros")
@@ -288,6 +400,16 @@ def model_to_dolphin01(
         model_out: np.ndarray,
         palette11: np.ndarray | None = None,
 ) -> np.ndarray:
+    """Convert model outputs to Dolphin's ``[0, 1]`` coordinate space.
+
+    Example
+    -------
+    * ``model_out = [[0.0, 1.0]]`` (float inputs) is clamped to the unit circle and
+      mapped to ``[[0.5, 1.0]]`` after scaling to ``[0, 1]``.
+    * ``model_out = [[2]]`` with ``palette11`` equal to the Fox stick palette
+      selects the third palette vector, clamps it if needed, and outputs the
+      corresponding ``[0, 1]`` coordinates.
+    """
     print(f"[TRACE:model_to_dolphin01] Converting model output, palette provided={palette11 is not None}")
     arr = np.asarray(model_out)
 
@@ -326,7 +448,21 @@ def collect_raw_inputs_from_gamestate(
         bot_port: int,
         opp_port: int,
 ) -> ModelFrameInputs:
-    """Extract both raw + transformed feature dictionaries expected by the model."""
+    """Extract both raw and transformed feature dictionaries with an example.
+
+    Example
+    -------
+    Given ``bot_port=1`` and ``opp_port=2`` the helper:
+
+    1. Extracts stage-level stats via :func:`extract_common_fields`.
+    2. Gathers player-specific values for both ports and prefixes them with
+       ``p1_``/``p2_``.
+    3. Coerces scalars, applies configured transforms, and validates that every
+       expected feature is present.
+
+    The returned :class:`ModelFrameInputs` therefore contains the raw mapping used
+    for logging and the transformed mapping used for inference.
+    """
     print(f"[TRACE:collect_raw_inputs_from_gamestate] bot_port={bot_port}, opp_port={opp_port}")
 
     ego_player = gamestate.players.get(bot_port)
@@ -366,6 +502,19 @@ class GPTInferenceEngine:
             self,
             checkpoint_path: str | Path,
     ) -> None:
+        """Load the GPT checkpoint and initialize inference buffers.
+
+        Example
+        -------
+        Constructing ``GPTInferenceEngine('checkpoint.pt')`` performs:
+
+        1. ``torch.load`` to retrieve the saved model state and training config.
+        2. Metadata loading from ``meta.json`` (if present) to recover
+           ``feature_names``, ``target_names``, and ``seq_len``.
+        3. Model instantiation on the resolved device and buffer setup so
+           :meth:`predict_from_raw` can immediately begin warm-up with neutral
+           controller states.
+        """
         print(f"[TRACE:GPTInferenceEngine.__init__] Loading checkpoint from {checkpoint_path}")
         ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
         train_cfg = ckpt.get("config", {})
@@ -462,6 +611,15 @@ class GPTInferenceEngine:
     # TODO: python loop - maybe vectorize?
     # TODO: Good candidate for a microbenchmark
     def _frame_to_tensor(self, raw_inputs: Dict[str, float]) -> torch.Tensor:
+        """Convert ``raw_inputs`` into an ordered tensor of feature values.
+
+        Example
+        -------
+        With ``self.feature_names = ['foo', 'bar']`` and ``raw_inputs`` containing
+        those keys, the returned tensor is ``tensor([foo_value, bar_value])``.
+        Missing keys raise ``KeyError`` through :func:`_safe_float`, making schema
+        issues visible during inference.
+        """
         print(f"[TRACE:GPTInferenceEngine._frame_to_tensor] Converting {len(raw_inputs)} inputs")
         frame = torch.zeros(self.feature_dim, dtype=torch.float32)
         for idx, name in enumerate(self.feature_names):
@@ -469,6 +627,15 @@ class GPTInferenceEngine:
         return frame
 
     def _stack_frames(self) -> Optional[torch.Tensor]:
+        """Stack buffered frames into a batch tensor when the buffer is non-empty.
+
+        Example
+        -------
+        If ``self.buffer`` holds three ``(F,)`` tensors, the method returns a
+        ``(1, 3, F)`` tensor ready for the model. When the buffer is empty (e.g.,
+        before warm-up completes) the method returns ``None`` to signal that
+        inference should keep emitting neutral actions.
+        """
         print(f"[TRACE:GPTInferenceEngine._stack_frames] Buffer size: {len(self.buffer)}")
         if not self.buffer:
             print("[TRACE:GPTInferenceEngine._stack_frames] Buffer empty, returning None")
@@ -479,12 +646,29 @@ class GPTInferenceEngine:
         return stacked.unsqueeze(0).to(self.device)
 
     def _build_inputs(self, batch_X: torch.Tensor) -> TensorDict:
+        """Wrap ``batch_X`` in the structured :class:`TensorDict` used by the model.
+
+        Example
+        -------
+        ``batch_X`` with shape ``(1, 256, F)`` is forwarded to
+        :func:`build_model_inputs`, which returns a dictionary containing the
+        original tensor plus positional encodings. This mirrors the exact input
+        contract used during training.
+        """
         print(f"[TRACE:GPTInferenceEngine._build_inputs] Building inputs from batch shape {batch_X.shape}")
         return build_model_inputs(batch_X, self.colmap)
 
     def _override_controller_features(
             self, features: Mapping[str, float]
     ) -> Dict[str, float]:
+        """Replace controller-related keys with cached values from prior outputs.
+
+        Example
+        -------
+        If ``features['p1_main_stick_x']`` equals ``0.2`` but the cached previous
+        value is ``0.5``, the returned dictionary substitutes ``0.5`` so the model
+        sees consistent controller history until a fresh prediction is available.
+        """
         print(
             f"[TRACE:GPTInferenceEngine._override_controller_features] Overriding {len(self._controller_feature_keys)} controller features")
         updated = dict(features)
@@ -494,6 +678,14 @@ class GPTInferenceEngine:
         return updated
 
     def _update_prev_controller_features(self, state: ControllerState) -> None:
+        """Cache the transformed controller state for future overrides.
+
+        Example
+        -------
+        After decoding ``state`` with main stick ``(0.7, 0.4)``, the method expands
+        it to feature keys, applies transforms if configured, and stores the result
+        so :meth:`_override_controller_features` can reuse them on the next frame.
+        """
         print("[TRACE:GPTInferenceEngine._update_prev_controller_features] Updating previous controller features")
         values = _controller_state_to_features("p1", state)
         if _FEATURE_TRANSFORMS_SPEC and _FEATURE_TRANSFORMS_SPEC.steps:
@@ -505,6 +697,15 @@ class GPTInferenceEngine:
             self._prev_controller_features = {k: float(v) for k, v in values.items()}
 
     def _snapshot_features(self, features: Mapping[str, float]) -> Dict[str, float]:
+        """Capture transformed feature values in model order.
+
+        Example
+        -------
+        For ``self.feature_names = ['foo', 'bar']`` and ``features`` containing
+        those keys, the returned dictionary is
+        ``{'foo': float(features['foo']), 'bar': float(features['bar'])}``.
+        Missing keys raise ``KeyError`` so logging never silently omits features.
+        """
         print(f"[TRACE:GPTInferenceEngine._snapshot_features] Snapshotting {len(self.feature_names)} features")
         snapshot: Dict[str, float] = {}
         for name in self.feature_names:
@@ -515,10 +716,25 @@ class GPTInferenceEngine:
         return snapshot
 
     def _snapshot_raw(self, raw_inputs: Mapping[str, float]) -> Dict[str, float]:
+        """Normalize raw mapping values into plain Python scalars.
+
+        Example
+        -------
+        ``_snapshot_raw({'foo': np.float32(1.23)})`` yields ``{'foo': 1.23}``,
+        making the snapshot JSON-serializable for death logs.
+        """
         print(f"[TRACE:GPTInferenceEngine._snapshot_raw] Snapshotting {len(raw_inputs)} raw inputs")
         return {name: _coerce_scalar(value) for name, value in raw_inputs.items()}
 
     def _snapshot_targets(self, raw_inputs: Mapping[str, float]) -> Dict[str, float]:
+        """Extract controller targets (sticks/buttons) from ``raw_inputs``.
+
+        Example
+        -------
+        If ``raw_inputs`` provides ``'p1_button_a': 1`` and ``'p1_main_stick_x': 0.6``
+        they appear in the returned dictionary. Missing keys trigger ``KeyError``
+        so controller logs remain aligned with the model schema.
+        """
         print(f"[TRACE:GPTInferenceEngine._snapshot_targets] Snapshotting {len(self.target_names)} targets")
         targets: Dict[str, float] = {}
         for name in self.target_names:
@@ -533,6 +749,15 @@ class GPTInferenceEngine:
     def _record_frame(
             self, model_features: Mapping[str, float], raw_inputs: Mapping[str, float]
     ) -> FrameRecord:
+        """Append the current frame's raw, transformed, and target data to history.
+
+        Example
+        -------
+        The method constructs a :class:`FrameRecord` using
+        :meth:`_snapshot_raw`, :meth:`_snapshot_features`, and
+        :meth:`_snapshot_targets`, appends it to ``self.frame_history``, and returns
+        the record so callers can store logits alongside it.
+        """
         print("[TRACE:GPTInferenceEngine._record_frame] Recording frame")
         record = FrameRecord(
             raw_features=self._snapshot_raw(raw_inputs),
@@ -544,6 +769,14 @@ class GPTInferenceEngine:
         return record
 
     def _capture_logits(self, outputs: TensorDict) -> Dict[str, Any]:
+        """Convert model logits into CPU lists for logging.
+
+        Example
+        -------
+        When ``outputs['buttons']`` is available, the method stores
+        ``outputs['buttons'][0, -1].detach().cpu().tolist()`` under the ``'buttons'``
+        key so the JSON death log records the exact logits that led to an action.
+        """
         print("[TRACE:GPTInferenceEngine._capture_logits] Capturing logits")
         logits: Dict[str, Any] = {}
         if "main_stick" in outputs:
@@ -565,6 +798,15 @@ class GPTInferenceEngine:
         return logits
 
     def _persist_death_record(self, stock_after: int) -> None:
+        """Write the current frame history to disk after a stock loss.
+
+        Example
+        -------
+        If the player goes from three to two stocks, the method dumps
+        ``self.frame_history`` into ``death_logs/death_000001.json`` including raw
+        features, transformed features, targets, and logits for every recorded
+        frame.
+        """
         print(f"[TRACE:GPTInferenceEngine._persist_death_record] Persisting death record, stock_after={stock_after}")
         frames = list(self.frame_history)
         if not frames:
@@ -609,6 +851,14 @@ class GPTInferenceEngine:
         self._death_counter += 1
 
     def _maybe_log_death(self, current_stock: Optional[float]) -> None:
+        """Detect stock drops and trigger :meth:`_persist_death_record`.
+
+        Example
+        -------
+        When ``self._prev_stock`` is ``3`` and ``current_stock`` equals ``2``, the
+        method saves the death log, increments counters, and resets tracking so the
+        next stock loss generates a fresh log.
+        """
         print(
             f"[TRACE:GPTInferenceEngine._maybe_log_death] current_stock={current_stock}, prev_stock={self._prev_stock}")
         if current_stock is None:
@@ -630,6 +880,16 @@ class GPTInferenceEngine:
     def _decode_stick(
             self, logits: torch.Tensor, palette: np.ndarray, stick_name: str
     ) -> np.ndarray:
+        """Convert stick logits into palette coordinates with an example.
+
+        Example
+        -------
+        If ``stick_name='main_stick'`` and ``logits=[2.0, 0.0, -1.0]`` over a
+        palette of three vectors, the method selects the ``argmax`` index ``0`` and
+        looks up the corresponding palette coordinate. When ``stick_name`` equals
+        ``'c_stick'`` it additionally computes ``softmax`` probabilities for
+        logging, mirroring the exact decoding performed during inference.
+        """
         print(f"[TRACE:GPTInferenceEngine._decode_stick] Decoding {stick_name}")
         # Decode sticks by selecting the most likely quantized bin (argmax).
         idx = torch.argmax(logits.detach(), dim=-1)
@@ -643,6 +903,16 @@ class GPTInferenceEngine:
         return xy01.reshape(-1)
 
     def _decode_buttons(self, probs: torch.Tensor) -> List[bool]:
+        """Sample button activations from probabilities using Bernoulli draws.
+
+        Example
+        -------
+        ``_decode_buttons(torch.tensor([[0.7, 0.2, 0.9, 0.1, 0.5]]))`` first clamps
+        probabilities to ``[eps, 1-eps]`` then samples a Bernoulli outcome for each
+        column, returning booleans such as ``[True, False, True, False, True]``.
+        Re-running with the same tensor and manual seed reproduces the same sample,
+        matching the stochastic decoding strategy used during evaluation.
+        """
         print("[TRACE:GPTInferenceEngine._decode_buttons] Decoding buttons")
         # Interpret button activations probabilistically, sampling directly from the model probabilities.
         eps = torch.finfo(probs.dtype).eps
@@ -654,6 +924,17 @@ class GPTInferenceEngine:
 
     # TODO: overly safe. decide on button logits or probs.
     def _decode_outputs(self, outputs: TensorDict) -> ControllerState:
+        """Assemble decoded sticks, buttons, and shoulder into controller output.
+
+        Example
+        -------
+        The method decodes main and C-stick logits via :meth:`_decode_stick`,
+        samples button booleans through :meth:`_decode_buttons`, and chooses the
+        highest-probability shoulder bin. If the shoulder palette is
+        ``[0.0, 0.5, 1.0]`` and logits favor index ``1``, the resulting
+        :class:`ControllerState` has ``shoulder_analog=0.5`` while the sticks hold
+        their decoded coordinates.
+        """
         print("[TRACE:GPTInferenceEngine._decode_outputs] Decoding model outputs")
         main_logits = outputs["main_stick"][0, -1]
         c_logits = outputs["c_stick"][0, -1]
@@ -699,6 +980,16 @@ class GPTInferenceEngine:
         )
 
     def prepare_inputs(self, raw_inputs: Mapping[str, float]) -> Optional[TensorDict]:
+        """Update the frame buffer and return model inputs when enough frames exist.
+
+        Example
+        -------
+        Feeding a new frame appends its tensor to the buffer. Before
+        ``self.warmup_frames`` are collected the method returns ``None``. Once the
+        buffer reaches that length, it stacks the frames and returns the
+        :class:`TensorDict` from :meth:`_build_inputs`, mirroring the workflow used
+        inside :meth:`predict_from_raw`.
+        """
         print("[TRACE:GPTInferenceEngine.prepare_inputs] Preparing inputs")
         frame = self._frame_to_tensor(raw_inputs)
         self.buffer.append(frame)
@@ -712,6 +1003,17 @@ class GPTInferenceEngine:
     def predict_from_raw(
             self, frame_inputs: Mapping[str, float] | ModelFrameInputs
     ) -> ControllerState:
+        """Run inference on raw or preprocessed frame inputs with a full walkthrough.
+
+        Example
+        -------
+        During warm-up, repeated calls buffer frames and return
+        :func:`ControllerState.neutral`. After ``warmup_frames`` are reached, the
+        method constructs inputs (or uses ``frame_inputs.transformed``), executes
+        the GPT model under ``torch.inference_mode()``, logs logits via
+        :meth:`_capture_logits`, decodes the outputs to a controller state, and
+        updates the override cache so the next call sees the latest controls.
+        """
         print(f"[TRACE:GPTInferenceEngine.predict_from_raw] Frame {self._frames_seen}")
         if isinstance(frame_inputs, ModelFrameInputs):
             print("[TRACE:GPTInferenceEngine.predict_from_raw] Input is ModelFrameInputs")
@@ -750,6 +1052,16 @@ _ACTIVE_ENGINE: Optional[GPTInferenceEngine] = None
 def apply_model_outputs_to_game(
         controller: Controller, model_outputs: ControllerState
 ) -> None:
+    """Apply ``model_outputs`` to the Dolphin controller with an example.
+
+    Example
+    -------
+    If ``model_outputs`` has ``button_a=True`` and ``main_stick=(0.8, 0.3)``, the
+    helper presses button A, tilts the main analog stick to ``(0.8, 0.3)``, and
+    releases any buttons marked ``False``. The shoulder analog is set via
+    ``press_shoulder`` using ``model_outputs.shoulder_analog``, reproducing the
+    exact physical controller state encoded in the :class:`ControllerState`.
+    """
     print("[TRACE:apply_model_outputs_to_game] Applying controller state to game")
     controller.release_all()
     if model_outputs.button_a:

--- a/train/batch_utils.py
+++ b/train/batch_utils.py
@@ -15,14 +15,43 @@ from controller_quantization import quantize_targets
 
 
 def build_model_inputs(batch_X: torch.FloatTensor, colmap: ColumnMap) -> TensorDict:
-    """Build TensorDict inputs for the model from batch features.
+    """Convert raw feature tensors into the structured ``TensorDict`` expected by the model.
+
+    The function slices the ``batch_X`` tensor using indices stored in ``colmap`` and casts
+    categorical features to ``torch.long`` so they can be consumed by embedding layers. Continuous
+    features (game state and controller values) remain floating point. The resulting dictionary is
+    wrapped in a ``TensorDict`` with the same batch shape as the input so downstream code can rely
+    on consistent key names.
+
+    Example:
+        Suppose ``batch_X`` is shaped ``[2, 3, 6]`` and the column map encodes indices such that
+        stage is at column 0, ego character at column 1, opponent character at column 2, ego action
+        at column 3, opponent action at column 4, and the remaining columns correspond to
+        ``gamestate`` (column 5 onwards) and ``controller`` (the last two columns). The first batch
+        might look like::
+
+            batch_X = torch.tensor([
+                [
+                    [3.0, 10.0, 20.0, 4.0, 12.0, 0.1, 0.2],
+                    [3.0, 10.0, 20.0, 4.0, 12.0, 0.3, 0.4],
+                    [2.0, 11.0, 21.0, 5.0, 13.0, 0.5, 0.6],
+                ]
+            ])
+
+        ``build_model_inputs`` will slice each column group, cast the five categorical columns to
+        integer type, and keep the last two columns as floating point. The returned ``TensorDict``
+        contains entries like ``{"stage": tensor([[[3], [3], [2]]], dtype=torch.long)}`` and
+        ``{"controller": tensor([[[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]])}``, demonstrating how each
+        slice of the original tensor is repackaged for the model.
 
     Args:
-        batch_X: [B, L, F] float32 features of current frame
-        colmap: Column mapping for feature indices
+        batch_X: ``[B, L, F]`` float32 features of the current frame sequence.
+        colmap: Column mapping for feature indices.
 
     Returns:
-        TensorDict with keys the model expects (stage, characters, actions, gamestate, controller)
+        ``TensorDict`` with the keys the model expects: ``stage``, ``ego_character``,
+        ``opponent_character``, ``ego_action``, ``opponent_action``, ``gamestate``, and
+        ``controller``.
     """
     B, L, _ = batch_X.shape
 
@@ -54,17 +83,27 @@ def build_model_inputs(batch_X: torch.FloatTensor, colmap: ColumnMap) -> TensorD
 def quantize_controller_targets(
         batch_Y: torch.Tensor, colmap: ColumnMap, input_domain: str = "unit11"
 ) -> Dict[str, torch.Tensor]:
-    """Quantize controller targets for loss computation.
+    """Quantize controller outputs to the discrete bins used by the loss functions.
 
-    Wrapper around controller_quantization.quantize_targets for consistency.
+    This is a thin wrapper around :func:`controller_quantization.quantize_targets` that provides a
+    consistent entry point for the rest of the training code.
+
+    Example:
+        If ``batch_Y`` contains a single sequence ``[[[0.0, 0.5], [0.2, -0.1]]]`` and the column map
+        reports that the first column is the main stick and the second is the C-stick, the wrapped
+        quantizer will convert those continuous values into categorical indices. With a quantization
+        scheme that maps ``0.0`` to bin ``4`` and ``0.5`` to bin ``7``, the resulting dictionary
+        includes tensors like ``{"main_idx": tensor([[4, 5]]), "c_idx": tensor([[7, 3]])}`` along
+        with masks describing which frames changed. The example shows how continuous values are
+        transformed step by step before being returned.
 
     Args:
-        batch_Y: [B, L, Y] target controller values
-        colmap: Column mapping for target indices
-        input_domain: Domain of input values ("unit11" or "unit01")
+        batch_Y: ``[B, L, Y]`` target controller values to quantize.
+        colmap: Column mapping for the target indices.
+        input_domain: Domain of input values (``"unit11"`` or ``"unit01"``).
 
     Returns:
-        Dictionary with quantized targets and metadata
+        Dictionary with quantized targets and metadata as produced by the underlying quantizer.
     """
     return quantize_targets(batch_Y, colmap, input_domain=input_domain)
 
@@ -83,6 +122,21 @@ class SampleWeightRatios:
 
 
 def _normalize(w: Tensor) -> Tensor:
+    """Scale weights so their mean is exactly one, avoiding degenerate zeros.
+
+    Example:
+        Passing ``w = tensor([[2.0, 4.0], [6.0, 8.0]])`` results in a mean of ``5.0``. The function
+        divides every entry by ``5.0 + 1e-12`` to produce
+        ``tensor([[0.4, 0.8], [1.2, 1.6]])``. The step-by-step scaling ensures that subsequent loss
+        computations treat the average weight as neutral while preserving the relative emphasis of
+        each element.
+
+    Args:
+        w: Tensor of arbitrary shape containing positive sample weights.
+
+    Returns:
+        Tensor with the same shape as ``w`` where the mean value is one (up to numerical precision).
+    """
     return w / (w.mean() + 1e-12)
 
 
@@ -94,13 +148,41 @@ def compute_component_sample_weights(
         ratios: Optional[SampleWeightRatios] = None,
         button_names: Optional[Sequence[str]] = None,
 ) -> Dict[str, Tensor]:
-    """
-    Build per-component loss weights:
-      - 'main':    [B, L]
-      - 'c':       [B, L]
-      - 'shoulder':[B, L] (if present, else ones)
-      - 'buttons': [B, L, K]
-      - 'global':  [B, L] (union-of-changes; can be useful for value head)
+    """Construct dynamic loss weights that emphasize frames where actions change.
+
+    The function inspects quantized controller targets to find frames where each component (main
+    stick, C-stick, shoulders, buttons) differs from the previous frame. Change frames receive the
+    up-weighting factors from :class:`SampleWeightRatios`, while hold frames receive the base weight.
+    The helper then normalizes each component so the average weight stays at one, ensuring the total
+    loss magnitude is stable.
+
+    Example:
+        Consider a tiny batch with ``B=1`` and ``L=4`` where the main stick indices are
+        ``[1, 1, 3, 3]`` and a single button toggles ``[0, 1, 1, 0]``. Using the default ratios,
+        ``compute_component_sample_weights``:
+
+        #. Detects that the main stick only changes at frame 2 (index ``3``) and assigns the
+           ``main_change`` weight ``8.0`` there while giving ``1.0`` to the hold frames.
+        #. For the button, it spots changes at frames 1 and 3, so those frames are weighted ``10.0``
+           while the others remain ``1.0``.
+        #. After normalizing, the returned tensors might look like ``main = tensor([[0.5, 0.5, 2.0, 2.0]])``
+           and ``buttons = tensor([[[0.4], [1.6], [1.6], [0.4]]])``, illustrating how each component
+           is scaled relative to the original ratios yet keeps a mean of one.
+
+    Args:
+        target_info: Mapping containing quantized indices and button states produced by
+            :func:`quantize_controller_targets`.
+        device: Target device for the constructed tensors.
+        ratios: Optional override for the default :class:`SampleWeightRatios`.
+        button_names: Optional list of button names that aligns with the ``buttons`` tensor.
+
+    Returns:
+        Dictionary with per-component weight tensors:
+
+        * ``"main"`` and ``"c"``: ``[B, L]``
+        * ``"shoulder"``: ``[B, L]`` (or ones if shoulders are absent)
+        * ``"buttons"``: ``[B, L, K]``
+        * ``"global"``: ``[B, L]`` union of all change indicators
     """
     r = ratios or SampleWeightRatios()
     B, L = target_info["main_idx"].shape

--- a/train/checkpoint.py
+++ b/train/checkpoint.py
@@ -11,12 +11,40 @@ from train.gradients import _move_optimizer_state_to_device
 
 
 def _sorted_checkpoint_paths(directory: Path) -> List[Path]:
+    """Return checkpoint files ordered from newest to oldest with a concrete example.
+
+    Example:
+        If ``directory`` contains ``[run1.pt, run2.pt]`` where ``run1.pt`` was modified at
+        ``12:00`` and ``run2.pt`` at ``12:05``, calling ``_sorted_checkpoint_paths`` yields the list
+        ``[run2.pt, run1.pt]``. The function gathers every ``*.pt`` file, inspects the modification
+        timestamps via ``Path.stat().st_mtime``, sorts in descending order, and returns the paths in
+        that precise sequence.
+
+    Args:
+        directory: Folder that potentially contains checkpoint ``.pt`` files.
+
+    Returns:
+        List of checkpoint paths sorted by modification time (newest first).
+    """
     checkpoints = [p for p in directory.glob("*.pt") if p.is_file()]
     checkpoints.sort(key=lambda p: p.stat().st_mtime, reverse=True)
     return checkpoints
 
 
 def _prune_checkpoints(directory: Path, keep: int = 10) -> None:
+    """Delete older checkpoints once more than ``keep`` files exist.
+
+    Example:
+        When ``directory`` holds ``[epoch1.pt, epoch2.pt, epoch3.pt]`` ordered newest to oldest and
+        ``keep`` is ``2``, the helper first calls :func:`_sorted_checkpoint_paths` to obtain the list
+        ``[epoch3.pt, epoch2.pt, epoch1.pt]``. It then iterates over every entry beyond the first two
+        (in this case ``epoch1.pt``) and unlinks it, leaving only the most recent checkpoints on
+        disk.
+
+    Args:
+        directory: Folder that stores checkpoint ``.pt`` files.
+        keep: Maximum number of recent checkpoints to retain.
+    """
     if keep <= 0:
         return
     checkpoints = _sorted_checkpoint_paths(directory)
@@ -28,6 +56,20 @@ def _prune_checkpoints(directory: Path, keep: int = 10) -> None:
 
 
 def _latest_checkpoint(directory: Path) -> Optional[Path]:
+    """Find the newest checkpoint in ``directory`` if one exists.
+
+    Example:
+        Given a folder containing ``ckpt_10.pt`` and ``ckpt_11.pt`` with modification times of
+        ``10:00`` and ``10:05`` respectively, ``_latest_checkpoint`` expands the path (handling
+        ``~``), filters to files ending in ``.pt``, sorts them by timestamp, and returns the
+        ``Path`` for ``ckpt_11.pt``. If no checkpoint files are present, it returns ``None``.
+
+    Args:
+        directory: Directory to search for checkpoints.
+
+    Returns:
+        Path to the most recent checkpoint or ``None`` if no files are found.
+    """
     directory = directory.expanduser()
     if not directory.exists():
         return None
@@ -45,6 +87,27 @@ def _load_latest_checkpoint(
     scaler: GradScaler,
     device: torch.device,
 ) -> Tuple[int, int, int]:
+    """Load the newest checkpoint and restore model, optimizer, and scaler state.
+
+    Example:
+        Imagine ``directory`` contains ``epoch_10.pt`` representing epoch 10 with
+        ``{"model": ..., "optimizer": ..., "scaler": ..., "global_step": 1280}``. When invoked,
+        the helper selects that file, calls :func:`torch.load`, and feeds the stored state dictionaries
+        into ``model.load_state_dict`` and ``optimizer.load_state_dict``. After adjusting for legacy
+        metadata, it returns ``(10, 1280, 0)`` indicating training should resume at epoch 10,
+        global step 1280, and iteration 0. If the directory is empty, ``(0, 0, 0)`` is returned
+        instead.
+
+    Args:
+        directory: Folder containing checkpoints.
+        model: Model instance whose parameters should be restored.
+        optimizer: Optimizer instance whose state should be restored.
+        scaler: Gradient scaler for mixed precision training.
+        device: Device to move optimizer state tensors onto.
+
+    Returns:
+        Tuple ``(start_epoch, global_step, start_iter)`` describing where to resume training.
+    """
     checkpoints = _sorted_checkpoint_paths(directory)
     if not checkpoints:
         return 0, 0, 0
@@ -111,7 +174,26 @@ def save_checkpoint(
     config: Optional[dict] = None,
     **kwargs,
 ) -> None:
-    """Save model checkpoint with optional optimizer and scaler state."""
+    """Persist the model state and optional training metadata to ``path``.
+
+    Example:
+        Calling ``save_checkpoint(Path("ckpts/epoch_5.pt"), model, optimizer, epoch=5, global_step=640)``
+        produces a dictionary containing at least the keys ``"model"``, ``"epoch"``,
+        ``"resume_epoch"``, ``"resume_iter"``, and ``"global_step"``. The helper ensures the parent
+        directory exists, then uses :func:`torch.save` to serialize the dictionary. Reloading the file
+        later will reproduce the exact state, demonstrating how inputs are collected and written to
+        disk step by step.
+
+    Args:
+        path: Destination path for the checkpoint file.
+        model: Model whose parameters should be saved.
+        optimizer: Optional optimizer whose state should also be serialized.
+        scaler: Optional gradient scaler to persist for mixed precision runs.
+        epoch: Epoch number to record.
+        global_step: Global training step to record.
+        config: Optional configuration dictionary to embed in the checkpoint.
+        **kwargs: Additional key-value pairs to merge into the saved dictionary.
+    """
     ckpt = {
         "model": model.state_dict(),
         "epoch": epoch,

--- a/train/display.py
+++ b/train/display.py
@@ -14,7 +14,20 @@ _ACTION_VALUE_TO_NAME = {action.value: action.name for action in Action}
 
 
 def _format_value(value: object) -> str:
-    """Format numeric values with up to 6 significant figures."""
+    """Format numbers to six significant figures while leaving other objects untouched.
+
+    Example:
+        Calling ``_format_value(0.123456789)`` casts the input to ``float`` and formats it as the
+        string ``"0.123457"``. Passing ``_format_value("noop")`` skips numeric formatting and
+        simply returns ``"noop"``. The example demonstrates how the helper branches between numeric
+        and non-numeric inputs.
+
+    Args:
+        value: Value to format, typically a scalar extracted from a tensor or array.
+
+    Returns:
+        String representation with limited significant figures for numeric inputs.
+    """
     try:
         return f"{float(value):.6g}"
     except (TypeError, ValueError):
@@ -22,7 +35,20 @@ def _format_value(value: object) -> str:
 
 
 def _format_action(value: object) -> str:
-    """Format action enum values to their names."""
+    """Convert action enumeration indices back into descriptive names.
+
+    Example:
+        Suppose ``value`` is ``4`` and ``Action(4).name`` equals ``"JUMP"``. The helper casts the
+        value to ``int`` and looks it up in ``_ACTION_VALUE_TO_NAME``, producing ``"JUMP"``. If the
+        value were ``99`` (not a valid key), it would fall back to ``"99"``. This illustrates how the
+        function either resolves human-friendly labels or echoes the numeric input.
+
+    Args:
+        value: Numeric or string representation of the action index.
+
+    Returns:
+        Action name string if available, otherwise the original value as a string.
+    """
     try:
         idx = int(float(value))
     except (TypeError, ValueError):
@@ -38,7 +64,28 @@ def _print_table_block(
     max_columns: int = 8,
     formatters: Optional[Dict[str, Callable[[object], str]]] = None,
 ) -> None:
-    """Print a table of data with headers and formatted values."""
+    """Render a slice of ``data`` as a human-readable table, respecting ``max_columns``.
+
+    Example:
+        Given ``headers = ["x", "y"]`` and ``data = np.array([[1.0, 2.0], [3.0, 4.0]])``, the
+        helper prints::
+
+            Example (columns 1-2 of 2):
+                 frame      x      y
+                 0          1      2
+                 1          3      4
+
+        It iterates column blocks of size ``max_columns``, formats each cell (using custom
+        ``formatters`` when provided), right-justifies the headers, and prints each row preceded by
+        the frame index. This step-by-step process mirrors how batches are previewed in logs.
+
+    Args:
+        title: Label printed above the table block.
+        headers: Column names corresponding to the last dimension of ``data``.
+        data: Two-dimensional slice to display (``num_rows`` by ``num_cols``).
+        max_columns: Maximum number of columns to display per block.
+        formatters: Optional mapping from column name to custom formatter function.
+    """
     if data.size == 0 or not len(headers):
         print(f"{title}: <empty>")
         return
@@ -88,7 +135,28 @@ def print_batch_preview(
     *,
     max_frames: int = 10,
 ) -> None:
-    """Pretty-print the first sequence from the first batch for manual inspection."""
+    """Preview the first sequence of a batch, showing how tensors map to readable tables.
+
+    Example:
+        Imagine ``batch["X"]`` is shaped ``[2, 4, 3]`` with the first sequence::
+
+            [[0., 10., 0.1],
+             [1., 11., 0.2],
+             [2., 12., 0.3],
+             [3., 13., 0.4]]
+
+        and ``feature_names = ["frame", "action", "value"]``. ``print_batch_preview`` slices the
+        first ``max_frames`` rows (``4`` here), converts them to ``numpy``, and passes them to
+        :func:`_print_table_block`, resulting in a console table where the ``action`` column is
+        formatted via :func:`_format_action` if applicable. The example demonstrates how tensor data
+        becomes a readable summary for quick debugging.
+
+    Args:
+        batch: Dictionary containing ``"X"`` features and optionally ``"Y"`` targets.
+        feature_names: Names corresponding to the feature columns.
+        target_names: Names corresponding to the target columns.
+        max_frames: Maximum number of frames to display.
+    """
     X = batch["X"].detach().cpu()
     Y = batch["Y"].detach().cpu() if batch["Y"].numel() else None
 
@@ -123,7 +191,27 @@ def print_batch_preview(
 
 
 def _top_confusions(cm: torch.Tensor, k: int = 8) -> List[Tuple[int, int, int, float]]:
-    """Return top-k off-diagonal confusions as (true, pred, count, pct_of_offdiag)."""
+    """Extract the ``k`` most common misclassifications from a confusion matrix.
+
+    Example:
+        For a ``3x3`` matrix::
+
+            [[5, 2, 0],
+             [1, 7, 0],
+             [0, 3, 4]]
+
+        The off-diagonal counts sum to ``6``. Calling ``_top_confusions(cm, k=2)`` returns
+        ``[(2, 1, 3, 50.0), (0, 1, 2, 33.3)]`` meaning "class 2 predicted as 1" occurred three times
+        (50% of off-diagonal mistakes) and "class 0 predicted as 1" occurred twice (33.3%). The
+        walkthrough shows how counts are flattened, sorted, and converted back into coordinates.
+
+    Args:
+        cm: ``[K, K]`` confusion matrix.
+        k: Number of top misclassifications to return.
+
+    Returns:
+        List of tuples ``(true_idx, pred_idx, count, percent_of_off_diag)``.
+    """
     cm_np = cm.numpy()
     off = cm_np.copy()
     np.fill_diagonal(off, 0)
@@ -152,16 +240,30 @@ def format_confusion_matrix(
     title: str = "confusion",
     labels: Optional[Sequence[str]] = None,
 ) -> str:
-    """Render a confusion matrix or its top confusions in a compact string.
+    """Format a confusion matrix as text, falling back to top errors for large matrices.
+
+    Example:
+        With the ``3x3`` matrix from :func:`_top_confusions`, ``format_confusion_matrix`` first sees
+        that ``K=3`` is smaller than ``max_size``. It therefore prints the full table::
+
+            confusion: full 3x3
+                     | 00 01 02 | sum
+                 00:   5  2  0 |  7
+                 01:   1  7  0 |  8
+                 02:   0  3  4 |  7
+            diag% per row: 71.4 87.5 57.1
+
+        If ``K`` exceeded ``max_size``, it would call :func:`_top_confusions` and list the top
+        misclassifications instead. This demonstrates both code paths.
 
     Args:
-        cm: [K, K] confusion matrix
-        max_size: Maximum size to show full matrix (otherwise show top confusions)
-        title: Title for the output
-        labels: Optional label names for rows/columns
+        cm: ``[K, K]`` confusion matrix.
+        max_size: Largest matrix dimension that still prints in full.
+        title: Title prefix for the formatted output.
+        labels: Optional human-readable labels for rows and columns.
 
     Returns:
-        Formatted string representation
+        Multi-line string summarizing the confusion matrix or its top confusions.
     """
     K = cm.shape[0]
 
@@ -211,27 +313,39 @@ def format_confusion_matrix(
 
 
 def format_metrics_dict(metrics: Dict[str, float], precision: int = 3) -> str:
-    """Format a metrics dictionary as a compact string.
+    """Serialize metric key-value pairs into a comma-separated string.
+
+    Example:
+        For ``metrics = {"loss": 1.23456, "acc": 0.98765}`` and ``precision=2``, the helper sorts
+        the keys alphabetically, formats each number to two decimals, and joins them to produce
+        ``"acc=0.99, loss=1.23"``. This shows how each metric passes through formatting before being
+        returned.
 
     Args:
-        metrics: Dictionary of metric names to values
-        precision: Number of decimal places
+        metrics: Dictionary of metric names to values.
+        precision: Number of decimal places to display.
 
     Returns:
-        Formatted string like "acc=0.950, f1=0.823"
+        Comma-separated ``key=value`` pairs sorted by key.
     """
     parts = [f"{key}={value:.{precision}f}" for key, value in sorted(metrics.items())]
     return ", ".join(parts)
 
 
 def format_loss_summary(losses: Dict[str, float]) -> str:
-    """Format a loss dictionary as a compact string.
+    """Summarize loss components, highlighting the total and per-component values.
+
+    Example:
+        Given ``{"total": 1.2, "main": 0.5, "btn": 0.7}``, the helper builds the string
+        ``"total=1.2000 (btn=0.7000, main=0.5000)"`` by separating the total from the other keys and
+        formatting each to four decimals. If ``total`` were absent it would sum the components first.
+        The example traces how inputs are reordered and combined into the final message.
 
     Args:
-        losses: Dictionary of loss component names to values
+        losses: Dictionary of loss component names to values.
 
     Returns:
-        Formatted string like "total=1.234 (main=0.5, c=0.3, btn=0.4)"
+        Readable summary string emphasizing the total loss.
     """
     total = losses.get("total", sum(v for k, v in losses.items() if k != "total"))
     components = [f"{k}={v:.4f}" for k, v in sorted(losses.items()) if k != "total"]
@@ -249,18 +363,25 @@ def format_training_progress(
     loss: float,
     metrics: Dict[str, float],
 ) -> str:
-    """Format a training progress message.
+    """Compose a progress string combining epoch, step, loss, and metrics.
+
+    Example:
+        With ``epoch=1``, ``total_epochs=5``, ``step=32``, ``total_steps=100``, ``loss=0.4321``, and
+        ``metrics={"acc": 0.98}``, the helper formats the metrics via :func:`format_metrics_dict`
+        (yielding ``"acc=0.980"``) and returns the message ``"[Epoch 2/5, Step 32/100] loss=0.4321 |
+        acc=0.980"``. The example highlights how values are combined and 0-indexed epochs are
+        converted to human-friendly 1-indexed numbers.
 
     Args:
-        epoch: Current epoch (0-indexed)
-        total_epochs: Total number of epochs
-        step: Current step within epoch
-        total_steps: Total steps per epoch
-        loss: Current loss value
-        metrics: Dictionary of metrics to display
+        epoch: Current 0-indexed epoch.
+        total_epochs: Total number of epochs that will run.
+        step: Current step within the epoch.
+        total_steps: Total steps per epoch.
+        loss: Current loss value.
+        metrics: Dictionary of metrics to display.
 
     Returns:
-        Formatted progress string
+        Formatted progress string suitable for logging.
     """
     metric_str = format_metrics_dict(metrics)
     return f"[Epoch {epoch+1}/{total_epochs}, Step {step}/{total_steps}] loss={loss:.4f} | {metric_str}"

--- a/train/gradients.py
+++ b/train/gradients.py
@@ -12,7 +12,19 @@ from torch.optim import Optimizer
 
 
 def _move_optimizer_state_to_device(optimizer: Optimizer, device: torch.device) -> None:
-    """Move optimizer state tensors to specified device."""
+    """Relocate every tensor in an optimizer's state dictionary onto ``device``.
+
+    Example:
+        Consider an ``Adam`` optimizer tracking ``exp_avg`` and ``exp_avg_sq`` on CPU. Calling
+        ``_move_optimizer_state_to_device(optimizer, torch.device("cuda"))`` iterates through every
+        parameter's state, finds the tensors, and replaces them with GPU copies produced by
+        ``tensor.to(device)``. After the function completes, ``optimizer.state[p]["exp_avg"].device``
+        reports ``cuda:0`` for each parameter, showing the step-by-step migration.
+
+    Args:
+        optimizer: Optimizer whose internal state tensors should be moved.
+        device: Destination device.
+    """
     for state in optimizer.state.values():
         for key, value in list(state.items()):
             if isinstance(value, torch.Tensor):
@@ -22,7 +34,23 @@ def _move_optimizer_state_to_device(optimizer: Optimizer, device: torch.device) 
 def collect_gradient_diagnostics(
     model: torch.nn.Module, eps: float = 1e-12
 ) -> Dict[str, float]:
-    """Aggregate gradient statistics for monitoring numerical stability."""
+    """Aggregate gradient statistics for monitoring numerical stability with an explicit example.
+
+    Example:
+        Suppose ``model`` has two parameters with gradients ``tensor([1.0, -2.0])`` and
+        ``tensor([0.0, float('nan')])``. ``collect_gradient_diagnostics`` traverses each gradient,
+        accumulating sums (``total_sq = 1^2 + (-2)^2 = 5``), counting zeros (one element equals
+        ``0.0``), and tracking NaNs (one element). The returned dictionary therefore includes
+        ``{"total_norm": sqrt(5), "zero_count": 1, "nan_count": 1}`` among many other statistics.
+        This walkthrough mirrors the exact sequence of reductions performed by the function.
+
+    Args:
+        model: Module whose gradients will be inspected.
+        eps: Small constant used when computing gradient-to-parameter ratios.
+
+    Returns:
+        Dictionary mapping metric names to floating-point summaries of the gradients.
+    """
     total_sq = 0.0
     total_abs = 0.0
     total_sum = 0.0

--- a/train/lr_schedule.py
+++ b/train/lr_schedule.py
@@ -8,7 +8,29 @@ import math
 def cosine_lr_schedule(
         step: int, total_steps: int, base_lr: float, warmup: int = 0
 ) -> float:
-    """Cosine annealing learning rate schedule with optional warmup."""
+    """Compute the cosine-annealed learning rate for a specific training step.
+
+    Example:
+        With ``base_lr=0.001``, ``total_steps=100``, and ``warmup=10``:
+
+        #. For ``step=4`` (during warmup), the function returns
+           ``0.001 * (4 + 1) / 10 = 0.0005``.
+        #. For ``step=10`` (first step after warmup), ``progress = (10 - 10)/(100 - 10) = 0`` and the
+           cosine term equals ``1.0``, so the learning rate is ``0.001``.
+        #. For ``step=55``, ``progress ≈ 0.5`` and the cosine becomes ``cos(pi * 0.5) = 0`` yielding
+           ``0.0005``.
+
+        The example demonstrates the exact calculations from warmup scaling through cosine decay.
+
+    Args:
+        step: Zero-indexed training step.
+        total_steps: Total number of steps in the schedule.
+        base_lr: Base learning rate amplitude.
+        warmup: Number of warmup steps with linear ramp.
+
+    Returns:
+        Floating-point learning rate for the requested step.
+    """
     if step < warmup:
         return base_lr * (step + 1) / max(1, warmup)
     progress = (step - warmup) / max(1, total_steps - warmup)
@@ -16,7 +38,25 @@ def cosine_lr_schedule(
 
 
 def linear_warmup(step: int, warmup_steps: int, base_lr: float) -> float:
-    """Linear warmup learning rate schedule."""
+    """Linearly ramp the learning rate from zero to ``base_lr`` over ``warmup_steps`` steps.
+
+    Example:
+        When ``warmup_steps=5`` and ``base_lr=0.01``:
+
+        * ``step=0`` returns ``0.01 * (0 + 1) / 5 = 0.002``.
+        * ``step=4`` returns ``0.01 * 5 / 5 = 0.01`` (end of warmup).
+        * ``step=6`` exceeds the warmup window so the function clamps to ``base_lr=0.01``.
+
+        The example walks through each branch showing how the scaling factor is derived.
+
+    Args:
+        step: Zero-indexed training step.
+        warmup_steps: Number of warmup steps; if ``0`` the base learning rate is returned.
+        base_lr: Target learning rate once warmup is complete.
+
+    Returns:
+        Warmed learning rate for the provided step.
+    """
     if warmup_steps <= 0:
         return base_lr
     return base_lr * min(1.0, (step + 1) / warmup_steps)

--- a/train/metrics.py
+++ b/train/metrics.py
@@ -23,14 +23,22 @@ class MetricsAccumulator:
         K_shoulder: int,
         device: torch.device,
     ):
-        """Initialize metrics accumulator.
+        """Initialize tensors that accumulate accuracy-style statistics.
+
+        Example:
+            Instantiating ``MetricsAccumulator(3, 2, 4, 0, torch.device("cpu"))`` allocates zeroed
+            tensors such as ``self.main_correct`` and ``self.btn_tp`` with shapes derived from the
+            supplied ``K_*`` values. After initialization you can call
+            :meth:`update_stick_metrics` with predicted vs. true indices and the counters increment
+            accordingly, demonstrating how the constructor merely prepares storage while deferring
+            computation to the update methods.
 
         Args:
-            K_main: Number of main stick quantization bins
-            K_c: Number of C-stick quantization bins
-            K_buttons: Number of button outputs
-            K_shoulder: Number of shoulder quantization bins
-            device: Device for tensors
+            K_main: Number of main stick quantization bins.
+            K_c: Number of C-stick quantization bins.
+            K_buttons: Number of button outputs.
+            K_shoulder: Number of shoulder quantization bins.
+            device: Device on which running totals should be stored.
         """
         self.device = device
         self.K_main = K_main
@@ -76,7 +84,20 @@ class MetricsAccumulator:
         self.shoulder_maj_correct = torch.tensor(0, dtype=torch.long, device=device)
 
     def _majority_label(self, label_counts: torch.Tensor) -> int:
-        """Get the majority label from counts."""
+        """Return the index of the largest count, defaulting to zero for empty tensors.
+
+        Example:
+            If ``label_counts`` equals ``tensor([2, 5, 3])`` the method returns ``1`` because index 1
+            has the highest count ``5``. For an empty tensor ``tensor([])`` it immediately returns
+            ``0``. The example mirrors how the helper uses :func:`torch.argmax` to select the most
+            frequent label.
+
+        Args:
+            label_counts: Histogram of observed labels.
+
+        Returns:
+            Integer index of the majority label or ``0`` when ``label_counts`` has no elements.
+        """
         if label_counts.numel() == 0:
             return 0
         return int(torch.argmax(label_counts).item())
@@ -90,15 +111,25 @@ class MetricsAccumulator:
         repeat_baseline: Optional[torch.Tensor] = None,
         repeat_mask: Optional[torch.Tensor] = None,
     ) -> None:
-        """Update stick (main or C-stick) metrics.
+        """Update running accuracy counters for either the main stick or C-stick outputs.
+
+        Example:
+            Suppose the true indices are ``tensor([0, 1, 2])`` and the predictions are
+            ``tensor([0, 0, 2])`` for ``stick_type="main"``. The method increments
+            ``self.main_correct`` by ``2`` (frames 0 and 2 match) and ``self.main_total`` by ``3``.
+            If ``majority_baseline=0`` it also adds ``1`` to ``self.main_maj_correct`` because only
+            the first frame matches the baseline. Passing ``repeat_baseline=tensor([0, 1, 1])`` with a
+            ``repeat_mask`` that marks frames ``[False, True, True]`` adds one extra correct repeat to
+            ``self.main_rep_correct`` (frame 2) and increases ``self.main_rep_total`` by ``2``. The
+            walk-through demonstrates how each argument influences the tracked counters.
 
         Args:
-            pred_idx: Predicted indices [N]
-            true_idx: True indices [N]
-            stick_type: "main" or "c"
-            majority_baseline: Optional majority label for baseline
-            repeat_baseline: Optional repeat prediction [N]
-            repeat_mask: Optional mask for repeat frames [N]
+            pred_idx: Predicted indices ``[N]``.
+            true_idx: True indices ``[N]``.
+            stick_type: ``"main"`` or ``"c"`` selecting which counters to update.
+            majority_baseline: Optional majority label accuracy baseline.
+            repeat_baseline: Optional repeat prediction vector ``[N]``.
+            repeat_mask: Optional boolean mask ``[N]`` for frames eligible for repeat accuracy.
         """
         if stick_type == "main":
             correct_attr = "main_correct"
@@ -155,12 +186,24 @@ class MetricsAccumulator:
         true_buttons: torch.Tensor,
         logits: torch.Tensor,
     ) -> None:
-        """Update button metrics.
+        """Update precision/recall-style counters and exact match for button predictions.
+
+        Example:
+            For a batch with ``B=1``, ``L=2``, ``K=2`` where ``true_buttons`` equals
+            ``[[[1, 0], [0, 1]]]`` and ``pred_buttons`` equals ``[[[1, 0], [1, 1]]]``:
+
+            * The method flattens both tensors to ``[[1, 0], [0, 1]]`` vs. ``[[1, 0], [1, 1]]``.
+            * True positives become ``[1, 1]`` (buttons 0 and 1 each correct once).
+            * False positives become ``[1, 0]`` (button 0 predicted on frame 1 where it should be 0).
+            * Exact match counts only the first frame, so ``self.btn_em_correct`` increases by ``1``
+              while ``self.btn_total`` increases by ``2``.
+
+            The example shows how each accumulation is derived step by step.
 
         Args:
-            pred_buttons: Predicted button states [B, L, K]
-            true_buttons: True button states [B, L, K]
-            logits: Button logits [B, L, K]
+            pred_buttons: Predicted button states ``[B, L, K]``.
+            true_buttons: True button states ``[B, L, K]``.
+            logits: Button logits ``[B, L, K]`` included for interface parity with callers.
         """
         B, L, K = pred_buttons.shape
 
@@ -195,12 +238,21 @@ class MetricsAccumulator:
         true_idx: torch.Tensor,
         majority_baseline: Optional[int] = None,
     ) -> None:
-        """Update shoulder metrics.
+        """Track accuracy for shoulder trigger quantization bins.
+
+        Example:
+            If ``self.K_shoulder`` is ``3`` and ``true_idx`` equals ``[[0, 1]]`` while
+            ``pred_idx`` equals ``[[0, 2]]``, the method increments ``self.shoulder_correct`` by ``1``
+            (only the first frame matches) and ``self.shoulder_total`` by ``2``. When
+            ``majority_baseline=0`` it adds another ``1`` to ``self.shoulder_maj_correct`` because the
+            baseline matches frame 0. The tensor ``self.shoulder_label_counts`` also updates to
+            ``[1, 1, 0]`` to reflect how often each class appears. This example makes the counter
+            updates explicit.
 
         Args:
-            pred_idx: Predicted indices [B, L]
-            true_idx: True indices [B, L]
-            majority_baseline: Optional majority label for baseline
+            pred_idx: Predicted indices ``[B, L]``.
+            true_idx: True indices ``[B, L]``.
+            majority_baseline: Optional majority label for baseline comparisons.
         """
         if self.K_shoulder <= 0:
             return
@@ -224,10 +276,17 @@ class MetricsAccumulator:
             self.shoulder_maj_correct += maj_correct
 
     def get_summary(self) -> Dict[str, float]:
-        """Get summary of all metrics.
+        """Convert accumulated counters into scalar metrics ready for logging.
+
+        Example:
+            After calling :meth:`update_button_metrics` for the example above, where
+            ``self.btn_em_correct == 1`` and ``self.btn_total == 2``, ``get_summary()`` computes
+            ``btn_em = 1 / 2 = 0.5``. Similarly, if ``self.main_correct == 8`` and ``self.main_total == 10``
+            it reports ``acc_main = 0.8``. The method performs these divisions for every component and
+            bundles the results into a dictionary, demonstrating the final aggregation step.
 
         Returns:
-            Dictionary of metric names to values
+            Dictionary of scalar metrics such as ``acc_main`` and ``btn_f1_micro``.
         """
         summary = {}
 
@@ -320,7 +379,14 @@ class MetricsAccumulator:
         return summary
 
     def reset(self) -> None:
-        """Reset all metrics to zero."""
+        """Zero out every counter so the accumulator can be reused for a new epoch.
+
+        Example:
+            After multiple updates the tensor ``self.main_correct`` might equal ``tensor(42)``.
+            Calling ``reset()`` sets it back to ``tensor(0)`` using in-place ``zero_()`` operations on
+            every field, including nested tensors such as ``self.btn_tp``. The example highlights how
+            the method prepares the accumulator for the next round of tracking.
+        """
         # Main stick
         self.main_correct.zero_()
         self.main_total.zero_()
@@ -359,15 +425,27 @@ class MetricsAccumulator:
 def compute_confusion_matrix(
     true_flat: torch.Tensor, pred_flat: torch.Tensor, K: int
 ) -> torch.Tensor:
-    """Compute confusion matrix from flattened integer labels.
+    """Build a confusion matrix by counting ``(true, pred)`` index pairs.
+
+    Example:
+        With ``true_flat = tensor([0, 1, 1, 2])``, ``pred_flat = tensor([0, 2, 1, 2])`` and ``K = 3``,
+        the function forms the combined indices ``true * K + pred`` → ``[0, 5, 4, 8]``. The
+        ``torch.bincount`` call counts each occurrence, reshaping to::
+
+            [[1, 0, 0],
+             [0, 1, 1],
+             [0, 0, 1]]
+
+        representing how often each class was predicted. The example precisely traces the tensor
+        operations used to populate the matrix.
 
     Args:
-        true_flat: True labels [N]
-        pred_flat: Predicted labels [N]
-        K: Number of classes
+        true_flat: True labels ``[N]``.
+        pred_flat: Predicted labels ``[N]``.
+        K: Number of classes.
 
     Returns:
-        [K, K] confusion matrix on CPU
+        ``[K, K]`` confusion matrix on CPU.
     """
     tf = true_flat.to(torch.int64)
     pf = pred_flat.to(torch.int64)
@@ -382,16 +460,24 @@ def compute_change_hold_accuracy(
     change_mask: torch.Tensor,
     hold_mask: torch.Tensor,
 ) -> Tuple[float, float]:
-    """Compute accuracy separately for change and hold frames.
+    """Measure accuracy for frames that changed versus those that stayed the same.
+
+    Example:
+        Suppose ``pred`` and ``true`` are ``[[0, 1, 1, 0]]`` and ``[[0, 0, 1, 0]]`` respectively with
+        ``change_mask = [[False, True, False, False]]`` and ``hold_mask`` as the logical NOT. The
+        helper computes ``correct = [True, False, True, True]``. ``change_accuracy`` averages the
+        single change frame (``False`` → ``0.0``) and ``hold_accuracy`` averages the remaining three
+        frames (``[True, True, True]`` → ``1.0``). The example mirrors the masking and averaging
+        operations exactly.
 
     Args:
-        pred: Predictions [B, L]
-        true: True labels [B, L]
-        change_mask: Boolean mask for change frames [B, L]
-        hold_mask: Boolean mask for hold frames [B, L]
+        pred: Predictions ``[B, L]``.
+        true: True labels ``[B, L]``.
+        change_mask: Boolean mask for change frames ``[B, L]``.
+        hold_mask: Boolean mask for hold frames ``[B, L]``.
 
     Returns:
-        (change_accuracy, hold_accuracy)
+        Tuple ``(change_accuracy, hold_accuracy)``.
     """
     correct = pred == true
 
@@ -411,14 +497,30 @@ def compute_change_hold_accuracy(
 def multilabel_prf(
     true_labels: torch.Tensor, pred_labels: torch.Tensor
 ) -> Tuple[float, float, float, float, float]:
-    """Compute multi-label precision, recall, F1.
+    """Calculate multi-label exact match, micro precision/recall/F1, and macro F1.
+
+    Example:
+        With ``true_labels = tensor([[[1, 0], [0, 1]]])`` and
+        ``pred_labels = tensor([[[1, 1], [0, 1]]])``:
+
+        * Flattening yields two frames with predictions ``[[1, 1], [0, 1]]`` and truths
+          ``[[1, 0], [0, 1]]``.
+        * True positives per class are ``[1, 1]``, false positives ``[0, 1]``, and false negatives
+          ``[0, 0]`` giving micro precision ``2/3`` and micro recall ``2/2 = 1`` → micro F1 ``0.8``.
+        * Macro F1 averages the per-class F1 scores: button 0 has precision ``1`` and recall ``1``
+          (F1 ``1``), button 1 has precision ``0.5`` and recall ``1`` (F1 ``2/3``), averaging to
+          ``0.8333``.
+        * Exact match checks each frame: the first differs because of button 1, so the final value is
+          ``0.5``.
+
+        The example exposes every intermediate count used in the calculations.
 
     Args:
-        true_labels: True labels [B, L, K] or [N, K]
-        pred_labels: Predicted labels [B, L, K] or [N, K]
+        true_labels: True labels ``[B, L, K]`` or ``[N, K]``.
+        pred_labels: Predicted labels ``[B, L, K]`` or ``[N, K]``.
 
     Returns:
-        (exact_match, precision_micro, recall_micro, f1_micro, f1_macro)
+        Tuple ``(exact_match, precision_micro, recall_micro, f1_micro, f1_macro)``.
     """
     # Ensure 3D
     if true_labels.dim() == 2:

--- a/train/value_head.py
+++ b/train/value_head.py
@@ -27,7 +27,21 @@ class RewardFeatureIdx:
 
 
 def build_reward_feature_index(colmap: ColumnMap) -> RewardFeatureIdx:
-    """Resolve feature indices once and reuse; avoids per-call .index() overhead."""
+    """Resolve frequently accessed feature indices from a :class:`ColumnMap` in one pass.
+
+    Example:
+        If ``colmap.feat_names`` equals ``["p1_stock", "p2_stock", "p1_percent"]``, calling
+        ``build_reward_feature_index`` returns ``RewardFeatureIdx(p1_stock=0, p2_stock=1,
+        p1_percent=2, ...)`` while any missing names (such as ``p2_percent``) remain ``None``. The
+        example demonstrates how the helper searches each feature name and records the integer
+        position so later reward computations can index into tensors without repeated list lookups.
+
+    Args:
+        colmap: Column mapping that lists feature names in order.
+
+    Returns:
+        :class:`RewardFeatureIdx` populated with index values where available.
+    """
     names = colmap.feat_names
 
     def idx(name: str) -> Optional[int]:
@@ -52,17 +66,29 @@ def compute_frame_rewards(
     *,
     idx: Optional[RewardFeatureIdx] = None,
 ) -> torch.Tensor:
-    """Compute per-frame rewards based on game state changes.
+    """Compute reward signals per frame using stock, damage, hitlag, and shield features.
 
-    Vectorized & allocation-lean version for efficient computation.
+    Example:
+        Consider ``B=1`` and ``L=3`` with stocks ``[4, 4, 3]`` and opponent percent damage
+        ``[0.10, 0.20, 0.25]`` (normalized 0–1). Using configuration weights
+        ``reward_stock_taken = 2`` and ``reward_damage_dealt = 0.5``:
+
+        #. ``torch.diff`` finds a stock drop of ``1`` at frame 2, so ``rw[:, 2]`` gains ``+2``.
+        #. Damage deltas are ``[+0.10, +0.05]``; the second frame adds ``0.10 * 100 * 0.5 = 5`` and
+           the third frame adds ``0.05 * 100 * 0.5 = 2.5``.
+        #. Summing the base reward ``reward_per_frame`` (call it ``r``) with these bonuses yields a
+           reward vector ``[r, r + 5, r + 2 + 2.5]``.
+
+        The example showcases each tensor operation—diffs, clamps, and adds—and how they manipulate
+        the inputs to produce the per-frame rewards.
 
     Args:
-        X: [B, L, F] input features
-        colmap: Column mapping
-        idx: Optional pre-computed reward feature indices
+        X: ``[B, L, F]`` input feature tensor.
+        colmap: Column mapping describing feature positions.
+        idx: Optional cached feature indices from :func:`build_reward_feature_index`.
 
     Returns:
-        [B, L] reward tensor
+        ``[B, L]`` tensor of per-frame rewards.
     """
     B, L, _F = X.shape
     device = X.device
@@ -135,7 +161,23 @@ _GAMMA_POW_CACHE: Dict[Tuple[int, float, torch.dtype, str, int], torch.Tensor] =
 def _gamma_cache_key(
     length: int, gamma: float, device: torch.device, dtype: torch.dtype
 ) -> Tuple[int, float, torch.dtype, str, int]:
-    """Create cache key for gamma powers."""
+    """Produce a hashable key describing the gamma power request for caching.
+
+    Example:
+        For ``length=4``, ``gamma=0.99``, ``device=torch.device('cuda', 0)``, and ``dtype=torch.float32``
+        the function returns ``(4, 0.99, torch.float32, 'cuda', 0)``. Requesting gamma powers with the
+        same inputs later reuses the cached tensor because the key matches exactly. This example shows
+        how each argument contributes to the key tuple.
+
+    Args:
+        length: Number of time steps required.
+        gamma: Discount factor.
+        device: Target device for the cached tensor.
+        dtype: Desired floating-point dtype.
+
+    Returns:
+        Tuple uniquely identifying the gamma power request.
+    """
     dev = torch.device(device)
     return (
         int(length),
@@ -150,7 +192,24 @@ def _gamma_cache_key(
 def _get_gamma_powers(
     length: int, gamma: float, device: torch.device, dtype: torch.dtype
 ) -> torch.Tensor:
-    """Get cached gamma powers or compute and cache them."""
+    """Return the vector ``[1, gamma, gamma^2, ...]`` either from cache or by recomputation.
+
+    Example:
+        Requesting ``_get_gamma_powers(3, 0.9, cpu_device, torch.float32)`` first builds the cache key
+        ``(3, 0.9, torch.float32, 'cpu', -1)``. If absent, it creates the tensor
+        ``tensor([1.0, 0.9, 0.81])`` via ``torch.pow`` and stores it in ``_GAMMA_POW_CACHE``. A second
+        call with the same arguments returns the cached tensor without recomputing. The example
+        highlights the control flow between cache hits and misses.
+
+    Args:
+        length: Number of gamma powers needed.
+        gamma: Discount factor.
+        device: Target device for the returned tensor.
+        dtype: Desired floating-point dtype of the result.
+
+    Returns:
+        Tensor of shape ``[length]`` containing successive gamma powers.
+    """
     if length <= 0:
         return torch.empty((0,), device=device, dtype=dtype)
 
@@ -179,16 +238,29 @@ def compute_value_targets(
     *,
     reward_idx: Optional[RewardFeatureIdx] = None,
 ) -> torch.Tensor:
-    """Compute discounted returns in O(B·L) using cached gamma powers and fused scans.
+    """Compute discounted returns by summing future rewards with geometric decay.
+
+    Example:
+        Suppose ``compute_frame_rewards`` yields ``[[1.0, 2.0, 3.0]]`` with ``gamma=0.9``. The helper
+        obtains gamma powers ``[1.0, 0.9, 0.81]`` and performs a reversed cumulative sum:
+
+        * Weighted rewards become ``[[1.0, 1.8, 2.43]]``.
+        * The reversed ``cumsum`` generates ``[[5.23, 4.23, 2.43]]``.
+        * Dividing by the gamma powers recovers the standard discounted returns
+          ``[[5.23, 4.7, 3.0]]``.
+
+        Finally the method adds the optional terminal bonus (contributing ``[0.81, 0.9, 1.0]`` in this
+        example) and unsqueezes the last dimension to produce ``[[[6.04], [5.6], [4.0]]]``. This
+        detailed walkthrough mirrors the tensor manipulations used in the implementation.
 
     Args:
-        X: [B, L, F] input features
-        colmap: Column mapping
-        gamma: Discount factor
-        reward_idx: Optional pre-computed reward feature indices
+        X: ``[B, L, F]`` input features.
+        colmap: Column mapping describing feature positions.
+        gamma: Discount factor used for future rewards.
+        reward_idx: Optional cached feature indices for faster reward computation.
 
     Returns:
-        [B, L, 1] value targets (discounted returns)
+        ``[B, L, 1]`` tensor of discounted returns.
     """
     B, L, _ = X.shape
     device = X.device

--- a/train/wandb_utils.py
+++ b/train/wandb_utils.py
@@ -38,15 +38,23 @@ def init_wandb(
     run_dir: Path,
     hyperparameters: Optional[Dict[str, Any]] = None,
 ) -> Optional[Any]:
-    """Initialize wandb with persistent run ID and resume support.
+    """Initialise a Weights & Biases run, persisting the run ID for automatic resume.
+
+    Example:
+        Suppose ``run_dir`` already contains ``wandb_run_id.txt`` with the value ``"abc123"``.
+        Calling ``init_wandb`` with ``config.project="demo"`` and ``config.mode="online"`` loads the
+        stored ID, sets ``WANDB_MODE=online`` in the environment, and calls ``wandb.init(project="demo",
+        dir=str(run_dir), id="abc123", resume="allow")``. The returned run object is then cached so
+        subsequent launches reuse the same dashboard entry. If wandb is unavailable, the function
+        simply returns ``None``, illustrating both control-flow branches.
 
     Args:
-        config: Wandb configuration
-        run_dir: Directory for run outputs (for storing run ID)
-        hyperparameters: Optional hyperparameters to log
+        config: Wandb configuration describing project metadata.
+        run_dir: Directory where wandb files (including run ID) are stored.
+        hyperparameters: Optional dictionary logged to wandb's config section.
 
     Returns:
-        wandb run object or None if wandb unavailable/disabled
+        Wandb run object or ``None`` if wandb is unavailable or disabled.
     """
     if not WANDB_AVAILABLE or config.mode == "disabled":
         return None
@@ -134,7 +142,14 @@ def init_wandb(
 
 
 def finish_wandb() -> None:
-    """Finish wandb run gracefully."""
+    """Terminate the active wandb run if logging is enabled.
+
+    Example:
+        After a run created by :func:`init_wandb`, calling ``finish_wandb()`` invokes
+        ``wandb.finish()`` inside a ``try`` block. If wandb was never initialised or raised an
+        exception, the call is skipped, leaving the application unharmed. This demonstrates the
+        defensive behaviour against missing dependencies.
+    """
     if WANDB_AVAILABLE and wandb is not None:
         try:
             wandb.finish()
@@ -149,11 +164,17 @@ class WandbLogger:
     """
 
     def __init__(self, wandb_run: Optional[Any] = None, enabled: bool = True):
-        """Initialize logger.
+        """Wrap a wandb run with convenience methods that degrade to no-ops.
+
+        Example:
+            Creating ``WandbLogger(run, enabled=True)`` stores ``run`` and sets ``self.enabled`` to
+            ``True``. Passing ``enabled=False`` forces ``self.enabled`` to ``False`` even when a run is
+            provided, making subsequent :meth:`log_metrics` calls skip wandb entirely. This example
+            highlights how the constructor decides whether logging should occur.
 
         Args:
-            wandb_run: Wandb run object (from wandb.init())
-            enabled: Whether logging is enabled
+            wandb_run: Wandb run object (from :func:`wandb.init`).
+            enabled: Whether logging should be performed.
         """
         self.run = wandb_run if WANDB_AVAILABLE else None
         self.enabled = enabled and self.run is not None
@@ -161,12 +182,18 @@ class WandbLogger:
     def log_metrics(
         self, metrics: Dict[str, float], step: int, commit: bool = True
     ) -> None:
-        """Log metrics to wandb.
+        """Send scalar metrics to wandb when logging is enabled.
+
+        Example:
+            With ``metrics={"loss": 0.5}`` and ``step=100``, calling ``log_metrics`` executes
+            ``wandb.log({"loss": 0.5}, step=100, commit=True)``. If ``self.enabled`` is ``False`` the
+            function returns immediately, illustrating the guard that prevents wandb usage when the
+            dependency is absent or disabled.
 
         Args:
-            metrics: Dictionary of metric names to values
-            step: Global step number
-            commit: Whether to commit the log (push to server)
+            metrics: Dictionary of metric names to values.
+            step: Global step number associated with the metrics.
+            commit: Whether to commit the log immediately (pushing to the server).
         """
         if not self.enabled or self.run is None:
             return
@@ -177,11 +204,17 @@ class WandbLogger:
             pass
 
     def log_gradients(self, grad_stats: Dict[str, float], step: int) -> None:
-        """Log gradient statistics to wandb.
+        """Prefix gradient statistics with ``gradients/`` and log them via :meth:`log_metrics`.
+
+        Example:
+            Given ``grad_stats={"total_norm": 3.2}`` and ``step=50``, the method first builds
+            ``{"gradients/total_norm": 3.2}`` and then calls ``log_metrics(..., commit=False)`` so the
+            gradient entry is batched with other logs. If logging is disabled the method exits without
+            modification. The example shows the exact transformation of keys and subsequent logging.
 
         Args:
-            grad_stats: Dictionary of gradient statistics
-            step: Global step number
+            grad_stats: Dictionary of gradient statistics.
+            step: Global step number.
         """
         if not self.enabled:
             return
@@ -191,11 +224,17 @@ class WandbLogger:
         self.log_metrics(prefixed, step, commit=False)
 
     def log_loss_components(self, losses: Dict[str, float], step: int) -> None:
-        """Log loss components to wandb.
+        """Record individual loss components under the ``loss/`` namespace.
+
+        Example:
+            For ``losses={"main": 0.3, "buttons": 0.2}`` the method constructs
+            ``{"loss/main": 0.3, "loss/buttons": 0.2}`` and invokes :meth:`log_metrics` with
+            ``commit=False``. This allows callers to combine loss logging with other statistics within
+            the same wandb step.
 
         Args:
-            losses: Dictionary of loss component names to values
-            step: Global step number
+            losses: Dictionary of loss component names to values.
+            step: Global step number.
         """
         if not self.enabled:
             return
@@ -205,10 +244,16 @@ class WandbLogger:
         self.log_metrics(prefixed, step, commit=False)
 
     def log_hyperparameters(self, params: Dict[str, Any]) -> None:
-        """Log hyperparameters to wandb config.
+        """Persist hyperparameters in ``wandb.config`` for reproducibility.
+
+        Example:
+            When ``params={"lr": 0.001, "batch_size": 64}``, the method iterates over the dictionary
+            and assigns ``wandb.config["lr"] = 0.001`` and ``wandb.config["batch_size"] = 64``. If
+            logging is disabled, the loop is skipped entirely. This showcases the mapping from input
+            dictionary to wandb's configuration namespace.
 
         Args:
-            params: Dictionary of hyperparameter names to values
+            params: Dictionary of hyperparameter names to values.
         """
         if not self.enabled or self.run is None:
             return
@@ -220,26 +265,38 @@ class WandbLogger:
             pass
 
     def should_log_this_step(self, step: int, frequency: int = 10) -> bool:
-        """Check if we should log at this step based on frequency.
+        """Return ``True`` when ``step`` is a multiple of ``frequency`` and logging is enabled.
+
+        Example:
+            With ``frequency=5`` and ``self.enabled=True``, calling ``should_log_this_step(10)`` returns
+            ``True`` because ``10 % 5 == 0``. Calling ``should_log_this_step(11)`` returns ``False``.
+            If ``self.enabled`` were ``False`` both calls would return ``False``. This demonstrates the
+            precise boolean condition used to decide whether to log.
 
         Args:
-            step: Current step number
-            frequency: Log every N steps
+            step: Current step number.
+            frequency: Log every ``N`` steps.
 
         Returns:
-            True if we should log
+            ``True`` if logging should happen this step, ``False`` otherwise.
         """
         return self.enabled and (step % frequency == 0)
 
     def watch_model(
         self, model: Any, log: str = "gradients", log_freq: int = 100
     ) -> None:
-        """Watch model for gradient/parameter tracking.
+        """Register a model with wandb's watch API when logging is active.
+
+        Example:
+            ``watch_model(model, log="all", log_freq=50)`` triggers ``wandb.watch`` with the same
+            arguments, enabling parameter and gradient histograms in the UI. If wandb is disabled the
+            method returns without side effects, illustrating the guard that prevents unnecessary API
+            calls.
 
         Args:
-            model: Model to watch
-            log: What to log ("gradients", "parameters", "all")
-            log_freq: How often to log
+            model: Model to watch.
+            log: What to log (``"gradients"``, ``"parameters"``, or ``"all"``).
+            log_freq: Frequency with which wandb should log model statistics.
         """
         if not self.enabled or self.run is None:
             return

--- a/window_dataset.py
+++ b/window_dataset.py
@@ -28,6 +28,16 @@ class _LRUEpisodeCache:
     """Tiny per-worker cache for opened episode arrays to cut directory lookups."""
 
     def __init__(self, max_open: int = 8) -> None:
+        """Initialize the cache and show how capacity behaves in practice.
+
+        Example
+        -------
+        ``cache = _LRUEpisodeCache(max_open=2)`` starts empty. After calling
+        ``cache.put((0, 1), (X0, Y0))`` and ``cache.put((0, 2), (X1, Y1))`` both
+        entries remain. Inserting ``cache.put((0, 3), (X2, Y2))`` pushes out the
+        oldest ``(0, 1)`` pair so subsequent ``get`` calls only see the two most
+        recently touched episodes.
+        """
         self.max_open = max_open
         self._keys: List[Tuple[int, int]] = []  # (shard_id, episode_id)
         self._vals: List[Tuple[zarr.Array, Optional[zarr.Array]]] = []
@@ -35,6 +45,15 @@ class _LRUEpisodeCache:
     def get(
         self, key: Tuple[int, int]
     ) -> Optional[Tuple[zarr.Array, Optional[zarr.Array]]]:
+        """Retrieve and mark an entry as recently used with a concrete trace.
+
+        Example
+        -------
+        If ``cache`` already stored ``(0, 5) -> (X5, None)`` and ``(0, 6) -> (X6, Y6)``,
+        calling ``cache.get((0, 5))`` returns ``(X5, None)`` and rotates that key to
+        the end of ``_keys`` so the next eviction would remove ``(0, 6)`` instead.
+        Requesting an unseen key yields ``None`` without mutating the cache.
+        """
         try:
             i = self._keys.index(key)
         except ValueError:
@@ -47,6 +66,17 @@ class _LRUEpisodeCache:
     def put(
         self, key: Tuple[int, int], value: Tuple[zarr.Array, Optional[zarr.Array]]
     ) -> None:
+        """Insert ``key`` while maintaining the maximum cache size.
+
+        Example
+        -------
+        Starting from ``[(0, 1), (0, 2)]`` in ``_keys`` with ``max_open=2``:
+
+        1. ``put((0, 2), v)`` updates the value and moves ``(0, 2)`` to the end so
+           it becomes the most recent entry.
+        2. ``put((0, 3), v3)`` appends ``(0, 3)`` and pops ``(0, 1)`` from the
+           front, ensuring only the two newest handles remain cached.
+        """
         if key in self._keys:
             i = self._keys.index(key)
             self._keys.pop(i)
@@ -67,6 +97,16 @@ class ZarrCorpusIndex:
     """
 
     def __init__(self, data_dir: str | Path) -> None:
+        """Load metadata and build prefix sums for global-window lookups.
+
+        Example
+        -------
+        When ``data_dir`` contains ``meta.json``, ``lengths.npy`` and two episodes
+        with window counts ``[3, 2]``, the constructor builds
+        ``_cumulative_windows=[3, 5]``. Later ``window_to_episode(4)`` uses this
+        array to return ``(1, 1)`` because the fifth global window belongs to
+        episode index ``1`` starting at offset ``1``.
+        """
         self.data_dir = Path(data_dir)
         meta_path = self.data_dir / "meta.json"
         lengths_path = self.data_dir / "lengths.npy"
@@ -122,9 +162,15 @@ class ZarrCorpusIndex:
             self._shard_paths[sid] = sdir
 
     def window_to_episode(self, global_win_idx: int) -> Tuple[int, int]:
-        """
-        Map global window index -> (episode_idx, start_offset).
-        start_offset is in [0, wins_in_episode-1].
+        """Map ``global_win_idx`` to an episode index and start offset.
+
+        Example
+        -------
+        With ``wins_per_ep = [3, 2]`` the cumulative windows are ``[3, 5]``. Calling
+        ``window_to_episode(2)`` returns ``(0, 2)`` because the third window still
+        falls within episode ``0`` at offset ``2``. Calling ``window_to_episode(3)``
+        returns ``(1, 0)`` showing how the search jumps to the next episode when the
+        index crosses a prefix boundary.
         """
         if not (0 <= global_win_idx < self.total_windows):
             raise IndexError(
@@ -138,6 +184,14 @@ class ZarrCorpusIndex:
         return ep_idx, offset
 
     def episode_start_global_index(self, ep_idx: int) -> int:
+        """Return the first global window index owned by ``ep_idx``.
+
+        Example
+        -------
+        Using the same ``wins_per_ep = [3, 2]`` example, ``ep_idx=0`` returns ``0``
+        while ``ep_idx=1`` returns ``3`` so you can offset local window indices by
+        this amount to obtain their global counterparts.
+        """
         if ep_idx == 0:
             return 0
         return int(self._cumulative_windows[ep_idx - 1])
@@ -148,8 +202,15 @@ class ZarrCorpusIndex:
         *,
         cache: Optional[_LRUEpisodeCache] = None,
     ) -> Tuple[zarr.Array, Optional[zarr.Array]]:
-        """
-        Returns (X_array, Y_array|None) for the episode.
+        """Open and optionally cache the ``X``/``Y`` arrays for ``ep``.
+
+        Example
+        -------
+        When ``ep`` describes ``episode_id=7`` in ``shard_00002.zarr``, the method
+        locates the shard directory, opens ``root['ep_000007']``, and returns the
+        ``X`` and ``Y`` arrays. Supplying a cache reuses the same handles when the
+        worker revisits the episode later in the same epoch, saving filesystem
+        round-trips.
         """
         key = (ep.shard_id, ep.episode_id)
         if cache is not None:
@@ -178,6 +239,16 @@ def _resolve_feature_groups(
     feature_names: Sequence[str],
     requested: Sequence[str],
 ) -> List[Tuple[int, ...]]:
+    """Expand requested feature names into column index groups with examples.
+
+    Example
+    -------
+    Suppose ``feature_names`` contains ``('p1_main_stick_x', 'p1_main_stick_y',
+    'p2_main_stick_x', 'p2_main_stick_y')`` and ``requested=('main_stick_x',
+    'main_stick_y')``. The helper first tries the names verbatim (fails) and then
+    matches both ``p1_`` and ``p2_`` prefixes, returning ``[(0, 1), (2, 3)]`` so
+    transforms run on each player slice independently.
+    """
     name_to_idx = {name: idx for idx, name in enumerate(feature_names)}
 
     if all(name in name_to_idx for name in requested):
@@ -208,6 +279,20 @@ def _resolve_feature_groups(
 def _apply_feature_transforms(
     X: np.ndarray, feature_names: Sequence[str], spec: Optional[FeatureTransformSpec]
 ) -> np.ndarray:
+    """Apply configured transforms to every requested column with a trace.
+
+    Example
+    -------
+    ``spec`` contains two steps:
+
+    1. ``('scale', features=('foo',), factor=0.5)``
+    2. ``('offset', features=('foo', 'bar'), delta=1)``
+
+    For input ``X = [[2., 5.], [4., 7.]]`` with feature names ``('foo', 'bar')`` we
+    first scale ``foo`` to ``[1., 2.]`` then add ``1`` to both columns yielding
+    ``[[2., 6.], [3., 8.]]``. The modified array is returned, demonstrating the
+    in-place but staged nature of the transform pipeline.
+    """
     if spec is None or not spec.steps:
         return X
 
@@ -263,6 +348,15 @@ class WindowDataset(Dataset):
         ep_cache_size: int = 8,
         return_numpy: bool = False,
     ) -> None:
+        """Prepare the dataset by indexing shards and wiring transforms.
+
+        Example
+        -------
+        ``WindowDataset('dataset_root', ep_cache_size=1)`` loads corpus metadata,
+        builds an LRU cache that keeps one episode open per worker, and stores the
+        requested transform spec so future ``__getitem__`` calls transparently
+        apply preprocessing before returning tensors.
+        """
         super().__init__()
         # TODO: Can we build this index faster? generator?
         self.index = ZarrCorpusIndex(data_dir)
@@ -281,9 +375,34 @@ class WindowDataset(Dataset):
         self._target_names_sel = list(self._target_names)
 
     def __len__(self) -> int:
+        """Return the total number of sliding windows across the corpus.
+
+        Example
+        -------
+        If the index reports ``total_windows=120_000`` this method simply returns
+        that value, matching how PyTorch uses ``len(dataset)`` to size an epoch.
+        """
         return self.index.total_windows
 
     def __getitem__(self, i: int) -> Dict[str, object]:
+        """Load window ``i`` and show each intermediate tensor transformation.
+
+        Example
+        -------
+        For ``seq_len=3`` and ``i=4``:
+
+        1. ``window_to_episode`` might yield ``(ep_idx=1, offset=1)`` so we slice
+           frames ``[1:4]`` from the episode arrays.
+        2. After copying into contiguous buffers we run feature transforms such as
+           scaling or palette snapping.
+        3. If ``return_numpy`` is ``False`` the arrays are converted to
+           ``torch.float32`` tensors and the target array defaults to shape
+           ``(3, 0)`` when an episode lacks ``Y`` data.
+
+        The method returns a dictionary containing the tensors alongside the
+        ``episode_id`` and the local ``start`` offset, mirroring the exact payload
+        consumed by the training loop.
+        """
         ep_idx, offset = self.index.window_to_episode(i)
         ep = self.index.episodes[ep_idx]
         start = offset  # within episode, window starts at this index
@@ -348,6 +467,15 @@ class RandomWindowSampler(Sampler[int]):
         stride: int = 1,
         generator: Optional[torch.Generator] = None,
     ) -> None:
+        """Create a sampler that enforces a stride across episode windows.
+
+        Example
+        -------
+        With ``stride=2`` and two episodes having window counts ``[3, 4]`` the
+        sampler's ``__iter__`` in epoch ``0`` yields offsets ``[0, 2, 0, 2]`` across
+        episodes, while epoch ``1`` produces ``[1, 3, 1, 3]`` (where valid). The
+        constructor stores the generator so shuffling remains reproducible.
+        """
         super().__init__()
         if stride < 1:
             raise ValueError("stride must be >= 1")
@@ -358,13 +486,39 @@ class RandomWindowSampler(Sampler[int]):
         self._start_offset = 0
 
     def set_epoch(self, epoch: int) -> None:
+        """Record the epoch so future iterations honor ``epoch % stride``.
+
+        Example
+        -------
+        Calling ``set_epoch(3)`` with ``stride=2`` means ``__iter__`` will only
+        visit windows whose local offsets satisfy ``t % 2 == 1`` because the epoch's
+        modulo is ``1``.
+        """
         self.epoch = int(epoch)
 
     def set_start_offset(self, offset: int) -> None:
-        """Skip the first `offset` samples the next time the sampler is iterated."""
+        """Skip the first ``offset`` samples the next time the sampler runs.
+
+        Example
+        -------
+        After drawing the indices ``[10, 20, 30]`` the sampler applies
+        ``set_start_offset(1)`` so the very next ``__iter__`` call discards ``10``
+        and starts yielding from ``20``. The internal counter resets to ``0`` after
+        iteration so future epochs consume the full sequence again.
+        """
         self._start_offset = max(0, int(offset))
 
     def _count_for_epoch(self, epoch: int) -> int:
+        """Count how many windows satisfy the stride for ``epoch``.
+
+        Example
+        -------
+        With ``stride=3`` and an episode containing ``5`` windows, epoch ``0``
+        contributes ``2`` windows (offsets ``0`` and ``3``). Epoch ``1`` contributes
+        offsets ``1`` and ``4`` (also ``2`` windows), while epoch ``2`` contributes
+        just offset ``2``. Summing across episodes produces the number returned by
+        ``__len__``.
+        """
         s = self.stride
         m = epoch % s
         total = 0
@@ -376,9 +530,27 @@ class RandomWindowSampler(Sampler[int]):
         return total
 
     def __len__(self) -> int:
+        """Return the number of indices that ``__iter__`` will generate.
+
+        Example
+        -------
+        For ``stride=2`` with window counts ``[3, 4]`` and ``epoch=0`` the helper
+        reports ``5`` because episode ``0`` contributes offsets ``0`` and ``2``
+        while episode ``1`` contributes ``0``, ``2`` and ``4``.
+        """
         return self._count_for_epoch(self.epoch)
 
     def __iter__(self) -> Iterator[int]:
+        """Yield global window indices for the configured stride with shuffling.
+
+        Example
+        -------
+        Continuing the ``stride=2`` scenario, ``__iter__`` first enumerates all
+        valid offsets that satisfy ``t % 2 == epoch % 2``. It then applies
+        ``torch.randperm`` when a generator is supplied, so two consecutive epochs
+        with the same seed produce identical shuffled orders, ensuring reproducible
+        training batches.
+        """
         s = self.stride
         m = self.epoch % s
 
@@ -412,8 +584,14 @@ class RandomWindowSampler(Sampler[int]):
 
 
 def worker_init_fn(worker_id: int) -> None:
-    """
-    Set distinct NumPy / PyTorch seeds for each worker. Avoids identical shuffles per worker.
+    """Seed NumPy and PyTorch for ``worker_id`` with a short computation trace.
+
+    Example
+    -------
+    When PyTorch assigns base seed ``123`` to the worker, this helper computes
+    ``base_seed = 123 % 2**31`` and seeds NumPy with ``base_seed + worker_id``. For
+    worker ``2`` the resulting NumPy seed is ``125`` so each DataLoader worker
+    shuffles batches differently.
     """
     # Same recipe as PyTorch DistributedSampler docs
     base_seed = torch.initial_seed() % 2**31
@@ -423,8 +601,22 @@ def worker_init_fn(worker_id: int) -> None:
 def make_dataloader() -> (
     Tuple[torch.utils.data.DataLoader, WindowDataset, Sampler[int]]
 ):
-    """
-    Builds dataset + sampler + DataLoader with tuned defaults.
+    """Construct the dataset, sampler, and DataLoader with an explicit example.
+
+    Example
+    -------
+    When configuration specifies ``batch_size=8``, ``stride=4`` and ``num_workers=2``
+    this function:
+
+    1. Builds ``WindowDataset`` with feature transforms from the config.
+    2. Instantiates :class:`RandomWindowSampler` using the dataset's index and the
+       configured stride.
+    3. Creates ``DataLoader`` with two workers, pinned memory (on CUDA), and
+       ``worker_init_fn`` so each worker gets a unique seed.
+
+    The three-tuple ``(loader, dataset, sampler)`` is returned so training scripts
+    can iterate over ``loader`` while still accessing ``dataset`` metadata and the
+    sampler to adjust epochs.
     """
     config = get_config()
     feature_spec = feature_spec_from_config(config.features)

--- a/zarr_storage.py
+++ b/zarr_storage.py
@@ -37,6 +37,14 @@ _C_STICK_PALETTE_NORM = np.sum(_C_STICK_PALETTE**2, axis=1, keepdims=True)
 
 # TODO: this is implemented elsewhere
 def _sticks01_to_unit11_np(xy01: np.ndarray) -> np.ndarray:
+    """Rescale ``[0, 1]`` stick coordinates to ``[-1, 1]`` while clamping overflow.
+
+    Example
+    -------
+    ``xy01 = [[0.0, 1.0], [0.75, 0.75]]`` becomes ``[[-0.7071, 0.7071], [0.5, 0.5]]``
+    after scaling and unit-circle projection, matching the preprocessing used in
+    dataset creation.
+    """
     xy01_clipped = np.clip(xy01, 0.0, 1.0)
     xy11 = xy01_clipped * 2.0 - 1.0
     norms = np.linalg.norm(xy11, axis=1, keepdims=True)
@@ -52,6 +60,15 @@ def _quantize_stick_block_np(
     palette: np.ndarray,
     palette_norm: np.ndarray,
 ) -> Tuple[np.ndarray, np.ndarray]:
+    """Snap ``values`` to the nearest stick palette entries with an example.
+
+    Example
+    -------
+    With ``values=[[0.2, 0.9], [1.1, -0.4]]`` and a four-direction palette, the
+    helper clamps the second row, computes squared distances to every palette
+    vector, and returns the closest palette coordinates along with their indices.
+    The result mirrors how controller targets are quantized during dataset build.
+    """
     if values.shape[1] != 2:
         raise ValueError("Stick quantization expects two columns (x, y).")
 
@@ -75,6 +92,14 @@ def _quantize_stick_block_np(
 
 
 def _quantize_shoulder_np(values: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Quantize shoulder analog values to the predefined palette.
+
+    Example
+    -------
+    ``values=[0.05, 0.9]`` yields palette values ``[0.0, 1.0]`` with indices
+    ``[0, 2]`` when ``SHOULDER_QUANTIZED=[0.0, 0.5, 1.0]``, showing the nearest
+    discrete shoulder levels stored alongside their indices.
+    """
     if _SHOULDER_PALETTE is None:
         raise RuntimeError("Shoulder quantization requested but no palette is defined.")
     arr = values.astype(np.float32, copy=False).reshape(-1)
@@ -85,11 +110,26 @@ def _quantize_shoulder_np(values: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
 
 
 def extract(game_state: GameState) -> Row:
+    """Extract a :class:`Row` of schema-aligned fields from ``game_state``.
+
+    Example
+    -------
+    For a frame where player 1 is at ``30%`` and holding right, the resulting
+    ``Row`` contains ``p1_percent=30`` and ``p1_main_stick_x≈1``. This matches the
+    row objects consumed by :func:`process_one_episode`.
+    """
     return extract_row(game_state)
 
 
 def _row_to_winner_first(rows: List[Row]) -> List[Row]:
-    """Ensure the winner is consistently treated as player 1."""
+    """Reorder ``rows`` so the winner consistently appears as player 1.
+
+    Example
+    -------
+    If the final row shows player 2 with more stocks, every row is swapped so the
+    eventual winner becomes ``p1``. When stocks tie, percent is used as the
+    tiebreaker, mirroring how training expects the protagonist to be indexed.
+    """
     if not rows:
         return rows
 
@@ -113,6 +153,14 @@ def _row_to_winner_first(rows: List[Row]) -> List[Row]:
 
 
 def _swap_row_players(row: Row) -> Row:
+    """Produce a new :class:`Row` with player 1/2 fields swapped.
+
+    Example
+    -------
+    Given ``Row(p1_percent=10, p2_percent=20, stage=1)`` the helper returns a row
+    where ``p1_percent=20`` and ``p2_percent=10`` while ``stage`` remains ``1``.
+    This is used by :func:`_row_to_winner_first` when flipping episode perspective.
+    """
     swap_values: dict[str, object] = {}
     for field in ROW_FIELDS:
         name = field.name
@@ -132,6 +180,15 @@ class Schema:
 
 
 def process_one_episode(raw_path: str) -> List[Row]:
+    """Convert an ``.slp`` replay into a list of schema rows with filtering steps.
+
+    Example
+    -------
+    For a valid two-player match, the function iterates console frames, skips
+    pre-game/invalid frames, extracts rows via :func:`extract`, and returns the
+    list. Errors before any row is collected raise ``ValueError`` so the caller can
+    discard the replay.
+    """
     console = Console(is_dolphin=False, allow_old_version=True, path=raw_path)
 
     if not console.connect():
@@ -170,6 +227,14 @@ def process_one_episode(raw_path: str) -> List[Row]:
 
 
 def _choose_chunk_t(F: int, elem_bytes: int) -> int:
+    """Pick the temporal chunk size ``T`` for Zarr arrays given ``F`` features.
+
+    Example
+    -------
+    With ``F=512`` and ``elem_bytes=4`` the helper approximates how many frames fit
+    in ``config.zarr.target_chunk_mb`` megabytes, then rounds to a multiple of
+    ``config.seq_len`` so sliding windows rarely straddle chunk boundaries.
+    """
     config = get_config()
     approx_t = int((config.zarr.target_chunk_mb * (1024**2)) / (F * elem_bytes))
     approx_t = max(config.seq_len, approx_t)
@@ -181,6 +246,14 @@ def _choose_chunk_t(F: int, elem_bytes: int) -> int:
 
 class EpisodeWriter:
     def __init__(self, schema: Schema, shard_path: str) -> None:
+        """Initialize a shard writer that buffers data in a temporary directory.
+
+        Example
+        -------
+        ``EpisodeWriter(schema, 'shard_00000.zarr')`` creates a temporary directory
+        ``shard_00000.zarr.tmp``. Calls to :meth:`write_episode` populate this temp
+        store until :meth:`finalize` atomically renames it into place.
+        """
         self.schema = schema
         self.shard_path = Path(shard_path)
         # write rows to a temporary dir then rename atomically on finalize
@@ -194,6 +267,14 @@ class EpisodeWriter:
         self._chunk_t_cache: dict[int, int] = {}
 
     def _chunk_t(self, F: int, elem_bytes: int = 4) -> int:
+        """Memoize the chunk length for feature dimension ``F``.
+
+        Example
+        -------
+        The first call with ``F=512`` computes the chunk length via
+        :func:`_choose_chunk_t` and caches it. Subsequent calls with the same ``F``
+        reuse the cached value, avoiding repeated configuration math.
+        """
         if F not in self._chunk_t_cache:
             ct = _choose_chunk_t(
                 F=F,
@@ -203,6 +284,16 @@ class EpisodeWriter:
         return self._chunk_t_cache[F]
 
     def write_episode(self, episode_id: int, X: np.ndarray, Y: np.ndarray) -> str:
+        """Write ``X``/``Y`` arrays for ``episode_id`` into the shard.
+
+        Example
+        -------
+        Given ``X`` with shape ``(300, F)`` and ``Y`` with ``(300, Yd)``, the method
+        creates ``ep_000123/X`` and ``ep_000123/Y`` arrays (chunked along time),
+        fills them with the provided data, and returns the episode group name. If
+        ``Y`` is empty the feature array is still written while the target dataset
+        is omitted.
+        """
         config = get_config()
         assert X.dtype == np.float32 and (Y.size == 0 or Y.dtype == np.float32)
         ep_name = f"ep_{episode_id:06d}"
@@ -233,6 +324,14 @@ class EpisodeWriter:
         return ep_name
 
     def finalize(self) -> None:
+        """Commit the temporary shard directory by renaming it into place.
+
+        Example
+        -------
+        After all episodes are written, :meth:`finalize` removes any existing shard
+        directory and renames ``shard_00000.zarr.tmp`` to ``shard_00000.zarr`` so
+        downstream readers see a consistent snapshot.
+        """
         self.tmp_path.flush() if hasattr(self.tmp_path, "flush") else None
         if self.shard_path.exists():
             shutil.rmtree(self.shard_path)
@@ -253,6 +352,15 @@ class ShardResult:
 def _rows_to_dense(
     rows: Sequence[object], schema: Schema
 ) -> Tuple[np.ndarray, np.ndarray, List[str], List[str], List[str], List[str]]:
+    """Convert a list of :class:`Row` objects into feature/target matrices.
+
+    Example
+    -------
+    For three rows ``r0, r1, r2`` the function builds ``X`` from ``r0`` and ``r1``
+    while ``Y`` uses ``r1`` and ``r2`` (one-step lookahead). It returns
+    ``float32`` arrays alongside the feature/target names and dtypes, matching the
+    tensors written into the final Zarr shards.
+    """
     T = len(rows)
     if T < 2:
         raise ValueError(f"Need at least 2 frames for temporal shifting, got {T}")
@@ -426,6 +534,14 @@ def _process_episode_task(
     raw_path: str,
     schema: Schema,
 ) -> Tuple[np.ndarray, np.ndarray, List[str], List[str], List[str], List[str]]:
+    """Process a single episode path inside the multiprocessing pool.
+
+    Example
+    -------
+    The worker calls :func:`process_one_episode` followed by :func:`_rows_to_dense`
+    and returns the resulting arrays and metadata, exactly as consumed by the main
+    dataset builder loop.
+    """
     rows = process_one_episode(raw_path)
     return _rows_to_dense(rows, schema)
 
@@ -436,6 +552,15 @@ def _merge_and_write_metadata(
     target_names: Sequence[str],
     out_root: str,
 ) -> None:
+    """Write index files, lengths, and ``meta.json`` for the built dataset.
+
+    Example
+    -------
+    Given shard results for two shards, the helper writes ``index.jsonl`` entries
+    referencing each episode/shard pair, saves ``lengths.npy`` and
+    ``wins_per_ep.npy``, and serializes ``meta.json`` with schema names and dtypes,
+    mirroring the artifacts consumed by :class:`ZarrCorpusIndex`.
+    """
     config = get_config()
     out_dir = Path(out_root)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -488,6 +613,16 @@ def _merge_and_write_metadata(
 def build_dataset(
     raw_episode_paths: Sequence[str], schema: Schema, out_root: str
 ) -> None:
+    """Parallelize replay processing and assemble Zarr shards with metadata.
+
+    Example
+    -------
+    When ``raw_episode_paths`` lists 10 files and the shard size is ``4``, the
+    function spins up workers via :func:`_process_episode_task`, streams completed
+    episodes into :class:`EpisodeWriter` instances per shard, and finally writes
+    ``index.jsonl``, ``lengths.npy``, and ``meta.json`` through
+    :func:`_merge_and_write_metadata`.
+    """
     config = get_config()
     N = len(raw_episode_paths)
     if N == 0:
@@ -610,6 +745,14 @@ def build_dataset(
 
 
 def create_melee_schema() -> Schema:
+    """Return a :class:`Schema` populated with default feature/target names.
+
+    Example
+    -------
+    Calling this helper wraps :func:`get_feature_names` and
+    :func:`get_target_names`, producing a schema object ready for
+    :func:`build_dataset`.
+    """
     return Schema(
         features=get_feature_names(),
         targets=get_target_names(),
@@ -617,6 +760,14 @@ def create_melee_schema() -> Schema:
 
 
 def main():
+    """Entry point that builds validation and training datasets from ``.slp`` files.
+
+    Example
+    -------
+    Running ``python zarr_storage.py`` discovers replay files under the configured
+    input root, builds validation then training shards via :func:`build_dataset`,
+    and prints summary statistics such as average frames per episode.
+    """
     import glob
 
     init_config()


### PR DESCRIPTION
## Summary
- expand controller quantization helpers with worked docstring examples
- add detailed explanations for feature transforms and inference helpers, including controller application
- document dataset windowing and Zarr storage utilities with step-by-step walkthroughs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690606eba4288323b2251b8e350abc5f