### PR TITLE
Reverse imbalance scale scheduling with configurable parameters

### DIFF
--- a/config/train_config.py
+++ b/config/train_config.py
@@ -36,6 +36,26 @@ class TrainConfig(BaseModel):
     label_smoothing: float = Field(default=0.02, ge=0, le=1)
     schedule_warmup_epochs: int = Field(default=1, ge=0)
     schedule_cooldown_epochs: int = Field(default=1, ge=0)
+
+    # Imbalance scale scheduling
+    imbalance_scale_initial: float = Field(
+        default=0.3,
+        ge=0,
+        le=1,
+        description="Initial imbalance scale value (used during warmup epoch)",
+    )
+    imbalance_scale_final: float = Field(
+        default=1.0,
+        ge=0,
+        le=1,
+        description="Final imbalance scale value (used during final portion of training)",
+    )
+    imbalance_scale_final_fraction: float = Field(
+        default=0.2,
+        ge=0,
+        le=1,
+        description="Fraction of training (after warmup) to keep at final imbalance scale",
+    )
     use_amp: bool = Field(default_factory=lambda: _should_use_amp())
     amp_dtype: str = Field(default_factory=lambda: _get_optimal_amp_dtype())
 

--- a/train/step.py
+++ b/train/step.py
@@ -52,12 +52,24 @@ def perform_forward_pass(
             )
         label_smoothing = float(max(label_smoothing, 0.0))
 
-        final_change_scale = 0.5
+        # Imbalance scale scheduling: ramps from initial to final value
+        # - Fixed at initial value during warmup (first epoch)
+        # - Fixed at final value during final fraction of training
+        # - Linear ramp in between
+        initial_scale = config.train.imbalance_scale_initial
+        final_scale = config.train.imbalance_scale_final
+        final_fraction = config.train.imbalance_scale_final_fraction
+
         if in_warmup:
-            imbalance_scale = 1.0
+            imbalance_scale = initial_scale
+        elif progress >= (1.0 - final_fraction):
+            imbalance_scale = final_scale
         else:
-            imbalance_scale = 1.0 - (1.0 - final_change_scale) * progress
-        imbalance_scale = float(max(min(imbalance_scale, 1.0), final_change_scale))
+            # Linear ramp from initial to final over the non-final portion
+            ramp_progress = progress / (1.0 - final_fraction)
+            imbalance_scale = initial_scale + (final_scale - initial_scale) * ramp_progress
+
+        imbalance_scale = float(max(min(imbalance_scale, final_scale), initial_scale))
 
         weights = compute_component_sample_weights(
             target_info,


### PR DESCRIPTION
Changes:
- Reversed imbalance scale from decreasing (1.0→0.5) to increasing (0.3→1.0)
- Added three configurable parameters to TrainConfig:
  - imbalance_scale_initial: Initial scale value (default: 0.3)
  - imbalance_scale_final: Final scale value (default: 1.0)
  - imbalance_scale_final_fraction: Fraction of training to hold at final value (default: 0.2)
- Updated scheduling logic:
  - Fixed at initial value during warmup (first epoch)
  - Linear ramp from initial to final during middle portion
  - Fixed at final value during last 20% of training